### PR TITLE
Uploads JSON as soon as the video loads

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -111,7 +111,7 @@ export default {
             }))
         )
         .then(() => this.setPlayerProperties(this.player))
-        .then(this.logData())
+        .then(() => this.logData())
         .catch((err) => console.log(err));
     },
 


### PR DESCRIPTION
Note: The JSON will be empty. It will look something like this
```
{
    "answers": [[], [], [], []], 
    "questions": ["Q1", "Q2", "Q3", "Q4"], 
    "options": [["", "", "", ""], ["", ""], ["", ""], ["", ""]], 
    "watch-time": 0
}
```

In the existing code, the JSON was uploading even when the video had not begun, but the first time it would be uploaded would've been 10 seconds after the video got loaded (because of the `setTimeOut`).

I just wrapped the method call (`this.logData()`) into a function which calls itself first, so it uploads instantly then it can go into the `setTimeOut` loop