### PR TITLE
Disabled keyboard actions + inverted time will not be shown

### DIFF
--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -110,8 +110,8 @@ export default {
               ],
 
               keyboard: {
-                    focused: false,
-                    global: false
+                focused: false,
+                global: false
               },
               
               invertTime: false,


### PR DESCRIPTION
- Usually time was being shown as inverted. (eg -4:36). 
- Keyboard actions like enter, spacebar, will not pause the video