### PR TITLE
ADD: YT embed if browser error, prominent gform link

### DIFF
--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -14,6 +14,9 @@
 
       <!-- TODO
       remove hardcoded link -> either parameterize it, or enter a link to youtube -->
+      <div class="lead_text">
+        <p>Plio को कैसे इस्तेमाल करना है, जानने के लिए ये video देखें </p>
+      </div>
       <div class='embed-container'>
         <iframe src='https://www.youtube.com/embed/FLOwzot27XM' frameborder='0' allowfullscreen>
         </iframe>
@@ -22,15 +25,24 @@
       <!-- failsafe begins -->
       <div v-if="hasFailSafe">
 
+        <!-- TODO - Adding loading spinner till YT video loads -->
         <!-- failsafe G-form begins -->
-        <div v-if="isFailSafeGform">
+        <div v-if="isFailSafeGform && isVideoIdFetched" >
+          <hr class="solid">
+
           <div class="lead_text">
-            <p>इसी प्रतियोगिता में Google फॉर्म से हिस्सा लेने के लिए नीचे बटन पे क्लिक करें</p>
+            <p>इसी प्रतियोगिता में Google फॉर्म से हिस्सा लेने के लिए नीचे दिया गया वीडियो देखें और उसके बाद Google फॉर्म का लिंक क्लिक करें </p>
+            <div class='embed-container'>
+              <iframe :src="this.value['youtubeId']" id="lesson-video" frameborder='0' allowfullscreen></iframe>
+            </div>
+            <br>
+            <i class="far fa-hand-point-right"></i>
             <a
-              :href=value.failsafeUrl
-              class="icon-block">
-              <img src="../assets/google_form.svg">
+            :href=value.failsafeUrl
+            class="icon-block" style="font-size:1.5em; width:3em;">
+              लिंक
             </a>
+            <i class="far fa-hand-point-left"></i>
             <hr class="solid">
           </div>
         </div>
@@ -81,6 +93,9 @@ export default {
     },
     isFailSafeGform() {
       return this.value['failsafeType'] === 'g-form'
+    },
+    isVideoIdFetched() {
+      return !!this.value['youtubeId']
     }
   }
 }

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -15,9 +15,8 @@
       <!-- failsafe begins -->
       <div v-if="hasFailSafe">
 
-        <!-- TODO - Adding loading spinner till YT video loads -->
         <!-- failsafe G-form begins -->
-        <div v-if="isFailSafeGform && isVideoIdFetched" >
+        <div v-if="isFailSafeGform && isVideoIdAvailable" >
           <hr class="solid">
 
           <div class="lead_text">
@@ -39,6 +38,17 @@
         <!-- failsafe G-form ends -->
 
       </div>
+
+      <div v-else-if="!hasFailSafe && isVideoIdAvailable">
+        <hr class="solid">
+
+        <div class="lead_text">
+          <p>नीचे दिया गया वीडियो देखें</p>
+          <div class='embed-container'>
+            <iframe :src="this.value['youtubeId']" id="lesson-video" frameborder='0' allowfullscreen></iframe>
+          </div>
+        </div>        
+      </div>
       <!-- failsafe ends -->
 
       <!-- TODO
@@ -47,8 +57,7 @@
         <p>Plio कैसे इस्तेमाल करना है, यह जानने के लिए यह video देखें </p>
       </div>
       <div class='embed-container'>
-        <iframe src='https://www.youtube.com/embed/FLOwzot27XM' frameborder='0' allowfullscreen>
-        </iframe>
+        <iframe :src='plioTutorialYT' frameborder='0' allowfullscreen> </iframe>
       </div>
 
       <hr class="solid">
@@ -79,6 +88,12 @@
 export default {
   name: "PageNotFound",
   props: ['type', 'value'],
+
+  data() {
+    return {
+      plioTutorialYT: "https://www.youtube.com/embed/FLOwzot27XM"
+    };
+  },
   
   created() {
     document.getElementById('nav').style.display = "none";
@@ -97,7 +112,7 @@ export default {
     isFailSafeGform() {
       return this.value['failsafeType'] === 'g-form'
     },
-    isVideoIdFetched() {
+    isVideoIdAvailable() {
       return !!this.value['youtubeId']
     }
   }

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="container">
-    <p class="emoji">&#128546;</p>
 
     <!-- 404 error starts -->
     <div v-if="isPageNotFound">
@@ -12,44 +11,48 @@
     <!-- Browser error starts -->
     <div v-if="isBrowserError">
 
-      <!-- failsafe begins -->
-      <div v-if="hasFailSafe">
+      <div v-if="isVideoIdAvailable">
 
-        <!-- failsafe G-form begins -->
-        <div v-if="isFailSafeGform && isVideoIdAvailable" >
-          <hr class="solid">
-
-          <div class="lead_text">
-            <p>नीचे दिया गया वीडियो देखें और उसके बाद Google फॉर्म के लिंक पे जाके प्रश्न करें</p>
-            <div class='embed-container'>
-              <iframe :src="this.value['youtubeId']" id="lesson-video" frameborder='0' allowfullscreen></iframe>
-            </div>
-            <br>
-            <i class="far fa-hand-point-right"></i>
-            <a
-            :href=value.failsafeUrl
-            class="icon-block" style="font-size:5vw; width:72vw;">
-              https://www.form.google.com
-            </a>
-            <i class="far fa-hand-point-left"></i>
-            <hr class="solid">
-          </div>
-        </div>
-        <!-- failsafe G-form ends -->
-
-      </div>
-
-      <div v-else-if="!hasFailSafe && isVideoIdAvailable">
-        <hr class="solid">
-
+        <!-- The lesson video in a YT iframe -->
         <div class="lead_text">
-          <p>नीचे दिया गया वीडियो देखें</p>
           <div class='embed-container'>
             <iframe :src="this.value['youtubeId']" id="lesson-video" frameborder='0' allowfullscreen></iframe>
           </div>
-        </div>        
+        </div>
+
+        <!-- failsafe begins -->
+        <div v-if="hasFailSafe">
+
+          <!-- failsafe G-form begins -->
+          <div v-if="isFailSafeGform" >
+            <hr class="solid">
+
+            <div class="lead_text">
+              <p>ऊपर दिया गया वीडियो देखें और उसके बाद Google फॉर्म के लिंक पे जाके प्रश्न करें</p>
+              <br>
+              <i class="far fa-hand-point-right"></i>
+              <a
+              :href=value.failsafeUrl
+              class="icon-block" style="font-size:5vw; width:72vw;">
+                https://www.form.google.com
+              </a>
+              <i class="far fa-hand-point-left"></i>
+              <hr class="solid">
+            </div>
+          </div>
+          <!-- failsafe G-form ends -->
+
+        </div>
+
+        <div v-else>
+          <hr class="solid">
+
+          <div class="lead_text">
+            <p>ऊपर दिया गया वीडियो देखें</p>
+          </div>        
+        </div>
+        <!-- failsafe ends -->
       </div>
-      <!-- failsafe ends -->
 
       <!-- TODO
       remove hardcoded link -> either parameterize it, or enter a link to youtube -->
@@ -63,6 +66,7 @@
       <hr class="solid">
       <br>
 
+      <p class="emoji">&#128546;</p>
       <div class="lead_text" >
         <p>यह वेबसाइट सिर्फ Google Chrome पे चलेगी </p>
         <p>This website will only work on Google Chrome</p>

--- a/src/views/Error.vue
+++ b/src/views/Error.vue
@@ -12,16 +12,6 @@
     <!-- Browser error starts -->
     <div v-if="isBrowserError">
 
-      <!-- TODO
-      remove hardcoded link -> either parameterize it, or enter a link to youtube -->
-      <div class="lead_text">
-        <p>Plio को कैसे इस्तेमाल करना है, जानने के लिए ये video देखें </p>
-      </div>
-      <div class='embed-container'>
-        <iframe src='https://www.youtube.com/embed/FLOwzot27XM' frameborder='0' allowfullscreen>
-        </iframe>
-      </div>
-
       <!-- failsafe begins -->
       <div v-if="hasFailSafe">
 
@@ -31,7 +21,7 @@
           <hr class="solid">
 
           <div class="lead_text">
-            <p>इसी प्रतियोगिता में Google फॉर्म से हिस्सा लेने के लिए नीचे दिया गया वीडियो देखें और उसके बाद Google फॉर्म का लिंक क्लिक करें </p>
+            <p>नीचे दिया गया वीडियो देखें और उसके बाद Google फॉर्म के लिंक पे जाके प्रश्न करें</p>
             <div class='embed-container'>
               <iframe :src="this.value['youtubeId']" id="lesson-video" frameborder='0' allowfullscreen></iframe>
             </div>
@@ -39,8 +29,8 @@
             <i class="far fa-hand-point-right"></i>
             <a
             :href=value.failsafeUrl
-            class="icon-block" style="font-size:1.5em; width:3em;">
-              लिंक
+            class="icon-block" style="font-size:5vw; width:72vw;">
+              https://www.form.google.com
             </a>
             <i class="far fa-hand-point-left"></i>
             <hr class="solid">
@@ -50,6 +40,19 @@
 
       </div>
       <!-- failsafe ends -->
+
+      <!-- TODO
+      remove hardcoded link -> either parameterize it, or enter a link to youtube -->
+      <div class="lead_text">
+        <p>Plio कैसे इस्तेमाल करना है, यह जानने के लिए यह video देखें </p>
+      </div>
+      <div class='embed-container'>
+        <iframe src='https://www.youtube.com/embed/FLOwzot27XM' frameborder='0' allowfullscreen>
+        </iframe>
+      </div>
+
+      <hr class="solid">
+      <br>
 
       <div class="lead_text" >
         <p>यह वेबसाइट सिर्फ Google Chrome पे चलेगी </p>

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -89,7 +89,8 @@ export default {
       isBrowserSupported: true,
       browserErrorHandlingValue: {
         'failsafeType': 'g-form',
-        'failsafeUrl': ''
+        'failsafeUrl': '',
+        'youtubeId': ''
       },
       journey: [],
       hasVideoPlayed: -1,
@@ -155,6 +156,7 @@ export default {
           this.videoId = res.data.videoId;
           this.plioId = res.data.plioId;
           this.browserErrorHandlingValue.failsafeUrl = res.data.plioDetails.failsafe;
+          this.browserErrorHandlingValue.youtubeId = "https://www.youtube.com/embed/" + this.videoId;
           this.isFullscreen = false;
           this.sessionId = res.data.sessionId;
           this.browser = res.data.userAgent['browser']['family'];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20169829/100541791-41feb380-326c-11eb-8b91-3b8fe19368e2.png)
------------------------------------------------

![image](https://user-images.githubusercontent.com/20169829/100541803-4c20b200-326c-11eb-9135-b627bddbb2a4.png)

This is how the error page will look like.

We realized that we were giving a failsafe g-form link but we were not giving the youtube video link.
Added a youtube embed here and made the g-form link such that it's easily visible.