### PR TITLE
NEW: progress will be saved across sessions

### DIFF
--- a/src/components/PlioQuestion.vue
+++ b/src/components/PlioQuestion.vue
@@ -32,6 +32,7 @@
                       name="options"
                       v-model="selectedOption"
                       :value="option"
+                      :id="option"
                       @click="selectOption(index)"
                     />{{ option }}
                   </label>
@@ -149,6 +150,10 @@ export default {
       // Wait 200 ms because it takes some time to find the DOM elements
       if (this.plioQuestion.state == "answered") {
         setTimeout(() => {
+          // highlight wrong/right depending on what the user answered in previous session
+          document.getElementById(this.plioQuestion.user_answer).checked = true
+          this.selectedOption = this.plioQuestion.user_answer
+          this.checkAnswer()
           this.showResult();
           this.selectedOption = null;
         }, 200);

--- a/src/components/PlioQuestion.vue
+++ b/src/components/PlioQuestion.vue
@@ -32,7 +32,6 @@
                       name="options"
                       v-model="selectedOption"
                       :value="option"
-                      :id="option"
                       @click="selectOption(index)"
                     />{{ option }}
                   </label>
@@ -151,7 +150,8 @@ export default {
       if (this.plioQuestion.state == "answered") {
         setTimeout(() => {
           // highlight wrong/right depending on what the user answered in previous session
-          document.getElementById(this.plioQuestion.user_answer).checked = true
+          var selectedOption = document.querySelectorAll(`input[value='${this.plioQuestion.user_answer}']`)[0];
+          selectedOption.checked = true
           this.selectedOption = this.plioQuestion.user_answer
           this.checkAnswer()
           this.showResult();

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -192,7 +192,7 @@ export default {
           this.times = res.data.times
 
           // merge the previous session data
-          if (res.data.sessionData != null) {
+          if (res.data.sessionData != '') {
             this.answers = res.data.sessionData.answers
             for (i=0; i < questions.length; i++){
               this.plioQuestions[i].user_answer = this.answers[i]

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -203,7 +203,7 @@ export default {
             this.journey = res.data.sessionData.journey
             this.previousPlayerTime = (
               (this.journey.length > 0) ? this.journey[this.journey.length - 1]['player_time'] : 0)
-            this.watchTime += res.data.sessionData['watch-time']
+            this.watchTime = res.data.sessionData['watch-time']
             this.retention = res.data.sessionData.retention
           }
         })
@@ -402,7 +402,7 @@ export default {
         }
 
         // start from beginning if video was watched till the end in the last session
-        if (this.previousPlayerTime == this.player.duration) {
+        if (this.player.duration - this.previousPlayerTime <= 2) {
           this.player.currentTime = 0
         }
 

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -400,9 +400,6 @@ export default {
         if (this.previousPlayerTime > stepBackTime){
           this.player.currentTime = this.previousPlayerTime - stepBackTime
         }
-        else{
-          this.player.currentTime = 0
-        }
 
         // start from beginning if video was watched till the end in the last session
         if (this.previousPlayerTime == this.player.duration) {

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -199,7 +199,7 @@ export default {
             
             this.journey = res.data.sessionData.journey
             this.previousPlayerTime = (
-              (this.journey.length > 0) ? this.journey[this.journey.length - 1]['player_time'] : [])
+              (this.journey.length > 0) ? this.journey[this.journey.length - 1]['player_time'] : 0)
             this.watchTime += res.data.sessionData['watch-time']
             this.retention = res.data.sessionData.retention
           }

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -74,8 +74,11 @@ var timeout = null;
 
 // wait this much time (secs) then show error page
 // if browser is not supported
-
 var browserCheckTime = 10;
+
+// how many seconds to step back (currentTime) when a user comes back to
+// a plio for a new session
+var stepBackTime = 5;
 
 export default {
   name: "Player",
@@ -393,7 +396,18 @@ export default {
 
     async setPlayerProperties(player) {
       player.on("ready", () => {
-        this.player.currentTime = Math.abs(this.previousPlayerTime - 5)
+        // start playing from 5 seconds before where the user left off in previous session
+        if (this.previousPlayerTime > stepBackTime){
+          this.player.currentTime = this.previousPlayerTime - stepBackTime
+        }
+        else{
+          this.player.currentTime = 0
+        }
+
+        // start from beginning if video was watched till the end in the last session
+        if (this.previousPlayerTime == this.player.duration) {
+          this.player.currentTime = 0
+        }
 
         var progressBar = document.querySelectorAll(".plyr__progress")[0];
         this.plioQuestions.forEach(function (plioQuestion) {


### PR DESCRIPTION
Progress will be persisted across sessions.

A user coming back to a specific plio, will get his/her progress persisted.

## What will be the same? 
- A new session id will be created (as before)
- A new JSON will be created (as before)

## What will be persisted and how?
- Answers will be persisted. For every question, only the VERY FIRST recorded answer is stored.
- This VERY FIRST recorded answer will be shown to the user (red/green highlighting) whenever they come back (as a new session) and re-visit a question. They can answer it again, but that will not change the data that's stored in the back.
- The questions that have been answered in previous sessions will be shown as green markers on the progress bar when the video loads, and the unanswered ones will stay as red.
- In a new session, the video will start playing ~ 5 seconds before where the user left the video in the previous session (like in youtube)
- Watch time will be accumulated. It keeps adding up for each session.
- Retention array will be persisted and new values will be added upon the existing array.
- journey will be persisted, and new journey steps will be added to the already existing ones.

## What will NOT be persisted?
- device/browser info, session-id, source will not be persisted as it makes sense to keep them unique in every session.