### PR TITLE
FIX: don't try updating locale when logged out

### DIFF
--- a/src/components/UserProperties.vue
+++ b/src/components/UserProperties.vue
@@ -34,12 +34,14 @@ export default {
     },
 
     updateLocale() {
-      var userConfigs = JSON.parse(this.$store.getters.getConfigs);
-      // change the locale
-      userConfigs["locale"] = this.$i18n.locale;
+      if (this.$$store.getters.isLoggedIn) {
+        var userConfigs = JSON.parse(this.$store.getters.getConfigs);
+        // change the locale
+        userConfigs["locale"] = this.$i18n.locale;
 
-      // update user config remotely and locally
-      this.updateUserConfigs(userConfigs);
+        // update user config remotely and locally
+        this.updateUserConfigs(userConfigs);
+      }
     },
 
     updateUserConfigs(userConfigs) {

--- a/src/components/UserProperties.vue
+++ b/src/components/UserProperties.vue
@@ -34,7 +34,7 @@ export default {
     },
 
     updateLocale() {
-      if (this.$$store.getters.isLoggedIn) {
+      if (this.$store.getters.isLoggedIn) {
         var userConfigs = JSON.parse(this.$store.getters.getConfigs);
         // change the locale
         userConfigs["locale"] = this.$i18n.locale;


### PR DESCRIPTION
Fixes #87 

## Summary
Only update locale if the user is logged in.

## Test Plan
Tested it locally - now, if logged out, no error is shown.