### PR TITLE
Bug fixes and new progress bar implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "ivideo_frontend",
             "version": "0.1.0",
             "dependencies": {
+                "@aacassandra/vue3-progressbar": "^1.0.3",
                 "@fortawesome/fontawesome-free": "^5.15.1",
                 "@fortawesome/fontawesome-svg-core": "^1.2.32",
                 "@fortawesome/free-solid-svg-icons": "^5.15.1",
@@ -42,6 +43,15 @@
                 "sass": "^1.26.11",
                 "sass-loader": "^10.0.2",
                 "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.4"
+            }
+        },
+        "node_modules/@aacassandra/vue3-progressbar": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@aacassandra/vue3-progressbar/-/vue3-progressbar-1.0.3.tgz",
+            "integrity": "sha512-e4SlgYwXiNABJbHYOChs3aSiCyR+1D6WAjWR1zo3vCs/9k6Vjj2GIPXWNJA/YP4RhlQS4eSC3RtCPC95CfAEbw==",
+            "dependencies": {
+                "core-js": "^3.6.5",
+                "vue": "^3.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -16677,6 +16687,15 @@
         }
     },
     "dependencies": {
+        "@aacassandra/vue3-progressbar": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@aacassandra/vue3-progressbar/-/vue3-progressbar-1.0.3.tgz",
+            "integrity": "sha512-e4SlgYwXiNABJbHYOChs3aSiCyR+1D6WAjWR1zo3vCs/9k6Vjj2GIPXWNJA/YP4RhlQS4eSC3RtCPC95CfAEbw==",
+            "requires": {
+                "core-js": "^3.6.5",
+                "vue": "^3.0.0"
+            }
+        },
         "@babel/code-frame": {
             "version": "7.12.13",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "i18n:report": "vue-cli-service i18n:report --src \"./src/**/*.?(js|vue)\" --locales \"./src/locales/**/*.json\""
     },
     "dependencies": {
+        "@aacassandra/vue3-progressbar": "^1.0.3",
         "@fortawesome/fontawesome-free": "^5.15.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
         "@fortawesome/free-solid-svg-icons": "^5.15.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,6 +69,7 @@
     <toast ref="toast"></toast>
     <router-view />
   </div>
+  <vue-progress-bar></vue-progress-bar>
 </template>
 
 <script>
@@ -110,6 +111,12 @@ export default {
     // set locale based on their config
     this.$refs.userConfig.setLocaleFromUserConfig();
   },
+  watch: {
+    pending(value) {
+      if (value) this.$Progress.start();
+      else this.$Progress.finish();
+    },
+  },
   methods: {
     // object spread operator
     // https://vuex.vuejs.org/guide/state.html#object-spread-operator
@@ -124,9 +131,9 @@ export default {
     createNewPlio() {
       // invoked when the user clicks on Create
       // creates a new draft plio and redirects the user to the editor
-      this.startLoading();
+      this.$Progress.start();
       PlioAPIService.createPlio().then((response) => {
-        this.stopLoading();
+        this.$Progress.finish();
         if (response.status == 201) {
           this.$router.push({
             name: "Editor",
@@ -177,7 +184,7 @@ export default {
     },
     isUserApproved() {
       // whether the user is an approved user or in waitlist
-      return this.user.status == "approved";
+      return this.user != null && this.user.status == "approved" ? true : false;
     },
   },
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -185,7 +185,7 @@ export default {
     },
     isUserApproved() {
       // whether the user is an approved user or in waitlist
-      return this.user != null && this.user.status == "approved" ? true : false;
+      return this.user != null && this.user.status == "approved"
     },
   },
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -113,6 +113,7 @@ export default {
   },
   watch: {
     pending(value) {
+      // start or finish progress bar depending on the value of "pending"
       if (value) this.$Progress.start();
       else this.$Progress.finish();
     },

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import i18n from "./services/Localisation/i18n.js";
 import PrimeVue from "primevue/config";
 import InlineSvg from "vue-inline-svg";
+import VueProgressBar from "@aacassandra/vue3-progressbar";
 
 import "primevue/resources/themes/saga-blue/theme.css";
 import "primevue/resources/primevue.min.css";
@@ -25,6 +26,20 @@ const gAuthOptions = {
   fetch_basic_profile: false,
 };
 
+const vueProgressBarOptions = {
+  color: "#F78000",
+  failedColor: "#874b4b",
+  thickness: "10px",
+  transition: {
+    speed: "0.2s",
+    opacity: "0.6s",
+    termination: 300,
+  },
+  autoRevert: true,
+  location: "top",
+  inverse: false,
+};
+
 const app = createApp(App).use(store).use(router);
 
 app.component("font-awesome-icon", FontAwesomeIcon);
@@ -34,5 +49,6 @@ app.use(i18n);
 app.use(PrimeVue, { ripple: true });
 app.use(ToastService);
 app.use(GAuth, gAuthOptions);
+app.use(VueProgressBar, vueProgressBarOptions);
 app.directive("tooltip", Tooltip);
 app.mount("#app");

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -72,7 +72,7 @@ export default {
     ...mapState("auth", ["activeWorkspace", "user"]),
     isUserApproved() {
       // whether the user is an approved user or in waitlist
-      return this.user.status == "approved";
+      return this.user != null && this.user.status == "approved" ? true : false;
     },
   },
   methods: {

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -72,7 +72,7 @@ export default {
     ...mapState("auth", ["activeWorkspace", "user"]),
     isUserApproved() {
       // whether the user is an approved user or in waitlist
-      return this.user != null && this.user.status == "approved" ? true : false;
+      return this.user != null && this.user.status == "approved";
     },
   },
   methods: {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-frontend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-frontend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/v2/style-guide/#Priority-A-Rules-Essential-Error-Prevention.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #182
Fixes #183 

## Summary

- [x] The table will NOT turn into a skeleton once "Create" button is clicked
- [x] Proper null checks have been added so when logging out, the console will not show an error when trying to find `status` inside `this.user`
- [x] Added an application level progress bar. It has been configured on `App.vue`. The progress bar will start and finish depending on the value of `this.pending` which comes via the vuex store. Benefit -- If for some process we don't want to toggle `this.pending` but we still want to show progress bar, we can skip doing `this.startLoading()` or `this.stopLoading()` and just use `this.$Progress.start()` or `this.$Progress.finish()`

## Test Plan
Tested locally
<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
