### PR TITLE
FIX: navigation guard for unapproved user

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -150,12 +150,17 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("auth", ["isAuthenticated"]),
+    ...mapGetters("auth", ["isAuthenticated", "isUserApproved"]),
     ...mapState("auth", ["config", "user", "activeWorkspace"]),
     ...mapState("sync", ["pending"]),
     showWorkspaceSwitcher() {
       // whether to show workspace switcher
-      return this.isAuthenticated && this.onHomePage && this.user.organizations.length;
+      return (
+        this.isAuthenticated &&
+        this.onHomePage &&
+        this.user.organizations.length &&
+        this.isUserApproved
+      );
     },
     onLoginPage() {
       // whether the current page is the login page
@@ -180,10 +185,6 @@ export default {
     coverBackground() {
       // whether to apply opacity to the background
       return this.showAlertDialog;
-    },
-    isUserApproved() {
-      // whether the user is an approved user or in waitlist
-      return this.user != null && this.user.status == "approved";
     },
   },
 };

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -36,7 +36,7 @@
 <script>
 import Table from "@/components/UI/Table/Table.vue";
 import PlioAPIService from "@/services/API/Plio.js";
-import { mapState, mapActions } from "vuex";
+import { mapState, mapActions, mapGetters } from "vuex";
 
 export default {
   name: "Home",
@@ -75,11 +75,8 @@ export default {
     if (this.isUserApproved) await this.fetchAllPlioIds();
   },
   computed: {
-    ...mapState("auth", ["activeWorkspace", "user"]),
-    isUserApproved() {
-      // whether the user is an approved user or in waitlist
-      return this.user != null && this.user.status == "approved";
-    },
+    ...mapState("auth", ["activeWorkspace"]),
+    ...mapGetters("auth", ["isUserApproved"]),
   },
   methods: {
     ...mapActions("plioItems", ["purgeAllPlios"]),

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -130,4 +130,8 @@ router.beforeEach((to, from, next) => {
   next();
 });
 
+// function restrictUnapprovedUser(to, from, next) {
+//   if
+// }
+
 export default router;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,7 @@ const routes = [
     name: "Editor",
     component: Editor,
     props: true,
+    beforeEnter: restrictUnapprovedUser,
     meta: { requiresAuth: true },
   },
   {
@@ -130,8 +131,12 @@ router.beforeEach((to, from, next) => {
   next();
 });
 
-// function restrictUnapprovedUser(to, from, next) {
-//   if
-// }
+function restrictUnapprovedUser(to, from, next) {
+  if (store.getters["auth/isUserApproved"]) {
+    next();
+    return;
+  }
+  next({ name: "Home", params: { org: to.params.org }, replace: true });
+}
 
 export default router;

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -12,6 +12,8 @@ const state = {
 const getters = {
   isAuthenticated: (state) => !!state.accessToken,
   locale: (state) => state.config.locale,
+  isUserApproved: (state) =>
+    state.user != null && state.user.status == "approved",
 };
 
 const actions = {


### PR DESCRIPTION
Fixes #198 

## Summary
- added getter for `isUserApproved`
- hide workspace switcher when user is unapproved
- adds navigation guard to prevent unapproved user from ever landing on the editor page

## Test Plan
Tested locally.
