### PR TITLE
Refresh cubejs access token on expiry

### DIFF
--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -108,7 +108,7 @@ export function apiClient() {
 export function analyticsAPIClient() {
   return cubejs(
     async () => {
-      if (!store.getters["auth/isAccessTokenValid"]) {
+      if (!store.getters["auth/isAnalyticsAccessTokenValid"]) {
         await store.dispatch("auth/getAnalyticsAccessToken");
       }
       return store.state.auth.analyticsAccessToken;

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -108,7 +108,7 @@ export function apiClient() {
 export function analyticsAPIClient() {
   return cubejs(
     async () => {
-      if (store.state.auth.analyticsAccessToken === null) {
+      if (!store.getters["auth/isAccessTokenValid"]) {
         await store.dispatch("auth/getAnalyticsAccessToken");
       }
       return store.state.auth.analyticsAccessToken;

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -11,6 +11,8 @@ const state = {
   isReAuthenticating: false,
   reAuthenticationPromise: null,
   analyticsAccessToken: null,
+  analyticsAccessTokenFetchTime: null,
+  analyticsAccessTokenExpiryTime: null,
 };
 
 const getters = {
@@ -27,6 +29,15 @@ const getters = {
       activeOrganizationSchema = activeOrganization.schema_name;
     }
     return activeOrganizationSchema;
+  },
+  isAccessTokenValid: (state) => {
+    if (state.analyticsAccessToken === null) return false;
+    const currentTime = new Date();
+    const timeDifference =
+      (currentTime - state.analyticsAccessTokenFetchTime) / 1000;
+    // return false if the token has expired
+    if (timeDifference > state.analyticsAccessTokenExpiryTime) return false;
+    return true;
   },
 };
 
@@ -120,9 +131,13 @@ const mutations = {
   },
   setAnalyticsAccessToken(state, accessToken) {
     state.analyticsAccessToken = accessToken.access_token;
+    state.analyticsAccessTokenFetchTime = new Date();
+    state.analyticsAccessTokenExpiryTime = accessToken.expires_in;
   },
   unsetAnalyticsAccessToken(state) {
     state.analyticsAccessToken = null;
+    state.analyticsAccessTokenFetchTime = null;
+    state.analyticsAccessTokenExpiryTime = null;
   },
 };
 

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -30,11 +30,10 @@ const getters = {
     }
     return activeOrganizationSchema;
   },
-  isAccessTokenValid: (state) => {
+  isAnalyticsAccessTokenValid: (state) => {
     if (state.analyticsAccessToken === null) return false;
-    const currentTime = new Date();
     const timeDifference =
-      (currentTime - state.analyticsAccessTokenFetchTime) / 1000;
+      (new Date() - state.analyticsAccessTokenFetchTime) / 1000;
     // return false if the token has expired
     if (timeDifference > state.analyticsAccessTokenExpiryTime) return false;
     return true;


### PR DESCRIPTION
Fixes #248 

## Summary
- checks if the time difference between current time of request and the time when access token was fetched has crossed the expiry time.

## Test Plan
Tested locally.