### PR TITLE
Temporary logging out users which have auth0 tokens

### DIFF
--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -101,6 +101,18 @@ client.interceptors.response.use(
   }
 );
 
+// Temporary code for Auth0 to AWS Cognito switch. To be removed after all users have switched to Cognito.
+((send) => {
+  XMLHttpRequest.prototype.send = async function (body) {
+    this.addEventListener("loadend", async () => {
+      if (this.status == 403) {
+        store.dispatch("auth/unsetAccessToken");
+      }
+    });
+    send.call(this, body);
+  };
+})(XMLHttpRequest.prototype.send);
+
 export function apiClient() {
   return client;
 }

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -105,7 +105,11 @@ client.interceptors.response.use(
 ((send) => {
   XMLHttpRequest.prototype.send = async function (body) {
     this.addEventListener("loadend", async () => {
-      if (this.status == 403) {
+      let analyticsApiBaseUrl = process.env.VUE_APP_CUBEJS_API_URL;
+      if (
+        this.responseURL.includes(analyticsApiBaseUrl) &&
+        this.status == 403
+      ) {
         store.dispatch("auth/unsetAccessToken");
       }
     });


### PR DESCRIPTION
## Summary

XHR event (to be used like interceptor). This will run for all the API calls and will log out user if any API call receives 403 error status. Distinguishing calls to backend API or cubejs API is going to be another task and since this is a one-time thing and needs to remove later, I think we can proceed with this.

## Test Plan

Needs some testing on staging and production once deployed.