### PR TITLE
Bunches cubeJS queries on the home page

### DIFF
--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -99,6 +99,7 @@ export default {
     return {
       tableColumns: ["name", "number_of_viewers"], // columns for the table
       tableData: [],
+      uniqueUsersList: [] // holds the number of unique users for all the plios fetched
       // dummy table data - to show skeletons when data is being loaded
       dummyTableData: Array(5).fill({
         name: { type: "component", value: "" },
@@ -178,7 +179,9 @@ export default {
           this.numberOfPliosPerPage = response.data.page_size; // set the page size
           this.prepareTableData(response.data.results); // prepare the data for the table
         }
-      );
+      ).then(() => {
+
+      });
     },
 
     createNewPlio() {
@@ -215,7 +218,7 @@ export default {
               break;
 
             case "number_of_viewers":
-              tableRow[column] = await PlioAPIService.getUniqueUsersCount(plioId);
+              tableRow[column] = uniqueUsersList[colIndex];
               break;
           }
         }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -99,7 +99,7 @@ export default {
     return {
       tableColumns: ["name", "number_of_viewers"], // columns for the table
       tableData: [],
-      uniqueUsersList: [], // holds the number of unique users for all the plios fetched
+      countUniqueUsersList: [], // holds the number of unique users for all the plios fetched
       // dummy table data - to show skeletons when data is being loaded
       dummyTableData: Array(5).fill({
         name: { type: "component", value: "" },
@@ -182,7 +182,7 @@ export default {
         .then(async (plioIdList) => {
           // fetch the list of unique users for each plio
           await PlioAPIService.getUniqueUsersCountList(plioIdList).then((response) => {
-            this.uniqueUsersList = response;
+            this.countUniqueUsersList = response;
           });
           return Promise.resolve(plioIdList);
         })
@@ -223,7 +223,7 @@ export default {
               break;
 
             case "number_of_viewers":
-              tableRow[column] = this.uniqueUsersList[plioIndex];
+              tableRow[column] = this.countUniqueUsersList[plioIndex];
               break;
           }
         }

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -223,7 +223,7 @@ export default {
               break;
 
             case "number_of_viewers":
-              tableRow[column] = this.uniqueUsersList[colIndex];
+              tableRow[column] = this.uniqueUsersList[plioIndex];
               break;
           }
         }

--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -16,6 +16,7 @@ import {
   percentageCompleteQuery,
   accuracyQuery,
   oneMinuteRetentionQuery,
+  uniqueUsersListQuery,
 } from "@/services/API/Queries/Plio.js";
 
 export default {
@@ -128,6 +129,29 @@ export default {
     var resultKey = resultSet.seriesNames().map((x) => x.key)[0];
     // https://cube.dev/docs/@cubejs-client-core#result-set-chart-pivot
     return resultSet.chartPivot()[0][resultKey];
+  },
+
+  async getUniqueUsersCountList(plioIds) {
+    var resultSet = await analyticsAPIClient().load(
+      uniqueUsersListQuery(plioIds)
+    );
+
+    // holds the mapping of plio ID to count
+    var resultsMap = {};
+    resultSet.series()[0].series.forEach((seriesItem) => {
+      resultsMap[seriesItem.x] = seriesItem.value;
+    });
+
+    // holds the final list of values to be returned
+    var results = [];
+    plioIds.forEach((plioId) => {
+      // plios which do not have any sessions do not show up in
+      // the resultMap - use a default value for those plios
+      if (resultsMap[plioId] == undefined) results.push(0);
+      else results.push(resultsMap[plioId]);
+    });
+
+    return results;
   },
 
   async getAverageWatchTime(plioId) {

--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -148,7 +148,7 @@ export default {
     plioIds.forEach((plioId) => {
       // plios which do not have any sessions do not show up in
       // the resultMap - use a default value for those plios
-      if (resultsMap[plioId] == undefined) results.push(0);
+      if (!(plioId in resultsMap)) results.push(0);
       else results.push(resultsMap[plioId]);
     });
 

--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -138,9 +138,10 @@ export default {
 
     // holds the mapping of plio ID to count
     var resultsMap = {};
-    resultSet.series()[0].series.forEach((seriesItem) => {
-      resultsMap[seriesItem.x] = seriesItem.value;
-    });
+    if (resultSet.series()[0] != undefined)
+      resultSet.series()[0].series.forEach((seriesItem) => {
+        resultsMap[seriesItem.x] = seriesItem.value;
+      });
 
     // holds the final list of values to be returned
     var results = [];

--- a/src/services/API/Queries/Plio.js
+++ b/src/services/API/Queries/Plio.js
@@ -13,6 +13,22 @@ export function uniqueUsersQuery(plioId) {
   };
 }
 
+export function uniqueUsersListQuery(plioIds) {
+  // query to fetch the number of unique users for the given list of plio IDs
+  // reference: https://cube.dev/docs/getting-started-cubejs-schema
+  return {
+    measures: ["Session.uniqueUsers"],
+    dimensions: ["Plio.uuid"],
+    filters: [
+      {
+        member: "Plio.uuid",
+        operator: "equals",
+        values: plioIds,
+      },
+    ],
+  };
+}
+
 export function averageWatchTimeQuery(plioId) {
   return {
     measures: ["GroupedSession.averageWatchTime"],


### PR DESCRIPTION
Fixes #240 

## Summary
- instead of making multiple queries for each plio, makes one query to CubeJS for fetching the list of all unique users.

## Test Plan
- [x] Tested locally
- [ ] Tested on staging
- [ ] Tested on production
