### PR TITLE
Access token expiration calculation had a bug

### DIFF
--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -32,7 +32,7 @@ const getters = {
   },
   isAnalyticsAccessTokenValid: (state) => {
     if (state.analyticsAccessToken === null) return false;
-    var currentTimeString = new Date().toString();
+    var currentTimeString = new Date(2021, 4, 26).toString();
     const timeDifference =
       (Date.parse(currentTimeString) -
         Date.parse(state.analyticsAccessTokenFetchTime)) /
@@ -134,7 +134,6 @@ const mutations = {
   setAnalyticsAccessToken(state, accessToken) {
     state.analyticsAccessToken = accessToken.access_token;
     state.analyticsAccessTokenFetchTime = new Date();
-    console.log(typeof state.analyticsAccessTokenFetchTime);
     state.analyticsAccessTokenExpiryTime = accessToken.expires_in;
   },
   unsetAnalyticsAccessToken(state) {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -32,8 +32,11 @@ const getters = {
   },
   isAnalyticsAccessTokenValid: (state) => {
     if (state.analyticsAccessToken === null) return false;
+    var currentTimeString = new Date().toString();
     const timeDifference =
-      (new Date() - state.analyticsAccessTokenFetchTime) / 1000;
+      (Date.parse(currentTimeString) -
+        Date.parse(state.analyticsAccessTokenFetchTime)) /
+      1000;
     // return false if the token has expired
     if (timeDifference > state.analyticsAccessTokenExpiryTime) return false;
     return true;
@@ -131,6 +134,7 @@ const mutations = {
   setAnalyticsAccessToken(state, accessToken) {
     state.analyticsAccessToken = accessToken.access_token;
     state.analyticsAccessTokenFetchTime = new Date();
+    console.log(typeof state.analyticsAccessTokenFetchTime);
     state.analyticsAccessTokenExpiryTime = accessToken.expires_in;
   },
   unsetAnalyticsAccessToken(state) {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -32,7 +32,7 @@ const getters = {
   },
   isAnalyticsAccessTokenValid: (state) => {
     if (state.analyticsAccessToken === null) return false;
-    var currentTimeString = new Date(2021, 4, 26).toString();
+    var currentTimeString = new Date().toString();
     const timeDifference =
       (Date.parse(currentTimeString) -
         Date.parse(state.analyticsAccessTokenFetchTime)) /


### PR DESCRIPTION
Fixes #283 

## Summary
- CubeJS token was getting expired but still CubeJS calls were being made which logged the user out
- CubeJS calls should not have been made with expired token but the code for checking if access token has expired had a bug

## Test Plan
- [x] Tested locally
- [ ] Tested on staging
- [ ] Tested on production