### PR TITLE
FIX: analytics query API call won't break now if plio id list is empty

### DIFF
--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -132,6 +132,8 @@ export default {
   },
 
   async getUniqueUsersCountList(plioIds) {
+    if (plioIds.length == 0) return [];
+
     var resultSet = await analyticsAPIClient().load(
       uniqueUsersListQuery(plioIds)
     );


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-frontend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-frontend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/v2/style-guide/#Priority-A-Rules-Essential-Error-Prevention.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #285 


## Test Plan

To replicate in prod (where the bug still exists), go to home page, search for a random string for which a plio won't exist, and see the error logged in the console.

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [x] Tested locally
- [x] Tested on staging
- [ ] Tested on production
