### PR TITLE
Removed sorting for "name" column, fixed sorting for "number of viewers" column

### DIFF
--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -203,7 +203,7 @@ export default {
       searchInputBoxClass:
         "w-full text-gray-700 leading-tight p-2 pl-4 focus:outline-none",
       // sort order for the "number of viewers" column. 1 - ascending, -1 - descending
-      numberOfViewersSortOrder: 1,
+      numViewersSortOrder: 1,
     };
   },
 
@@ -346,10 +346,13 @@ export default {
     },
     sortBy(columnName) {
       // toggle the sort order for "number_of_viewers" column
-      // and emit it to the parent (Home.vue)
+      // and emit the field to sort by, to the parent (Home.vue)
       if (columnName == "number_of_viewers") {
-        this.numberOfViewersSortOrder = this.numberOfViewersSortOrder * -1;
-        this.$emit("sort-by-number-of-viewers", this.numberOfViewersSortOrder);
+        this.numViewersSortOrder = this.numViewersSortOrder * -1;
+        this.$emit(
+          "sort-num-viewers",
+          this.numViewersSortOrder == -1 ? "-unique_viewers" : "unique_viewers"
+        );
       }
     },
     savePlioDetails(rowIndex, plioDetails) {
@@ -374,7 +377,7 @@ export default {
       // flip the icon if sort order changes
       // hide the icon for the "name" column
       return {
-        "transform rotate-180": this.numberOfViewersSortOrder == -1,
+        "transform rotate-180": this.numViewersSortOrder == -1,
         hidden: columnName == "name",
       };
     },
@@ -384,6 +387,6 @@ export default {
     },
   },
 
-  emits: ["search-plios", "reset-search-string", "sort-by-number-of-viewers"],
+  emits: ["search-plios", "reset-search-string", "sort-num-viewers"],
 };
 </script>

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -63,24 +63,14 @@
                 <tr>
                   <th
                     v-for="(columnName, columnIndex) in columns"
-                    @click="sortBy(columnName)"
                     :key="columnName"
                     scope="col"
                     class="sm:py-3 py-1.5 text-left text-xs sm:text-md font-medium text-gray-500 uppercase tracking-wider w-2/3"
                     :class="getColumnHeaderStyleClass(columnIndex)"
                   >
                     <div class="flex">
-                      <div
-                        class="p-1 my-auto whitespace-nowrap md:text-base xl:text-lg cursor-pointer"
-                      >
+                      <div class="p-1 my-auto whitespace-nowrap md:text-base xl:text-lg">
                         {{ tableColumnName(columnName) }}
-                      </div>
-                      <div class="p-1 my-auto cursor-pointer">
-                        <inline-svg
-                          :src="require('@/assets/images/chevron-down-solid.svg')"
-                          class="h-3 w-3 my-1 transition ease duration-800"
-                          :class="getSortIconStyleClass(columnName)"
-                        ></inline-svg>
                       </div>
                     </div>
                   </th>
@@ -89,7 +79,7 @@
               <tbody class="bg-white divide-y divide-gray-200">
                 <!-- table values -->
                 <tr
-                  v-for="(entry, rowIndex) in filteredData"
+                  v-for="(entry, rowIndex) in localData"
                   :key="entry"
                   :class="tableRowClass"
                   @mouseover="tableRowHoverOn(rowIndex)"
@@ -190,8 +180,6 @@ export default {
   },
   data() {
     return {
-      sortKey: "", // the key (table column) to sort the table on
-      sortOrders: {}, // store the sorting orders of all columns of the table - asc or desc
       searchString: "", // the string to use when filtering the results
       selectedRowIndex: null, // index of the row currently in focus / being hovered on
       // classes for the analyse button
@@ -210,7 +198,6 @@ export default {
   },
 
   created() {
-    this.initialiseSortOrders();
     this.startLoading();
   },
 
@@ -255,14 +242,14 @@ export default {
     },
     totalItemsInTable() {
       // total rows present in the table
-      return this.filteredData.length || 0;
+      return this.localData.length || 0;
     },
     isTableEmpty() {
       return this.totalItemsInTable == 0;
     },
-    filteredData() {
-      // contains the filtered data after applying sorting
-      return this.orderBySort(this.data);
+    localData() {
+      // contains the local copy of the table data
+      return this.data;
     },
     disabledElementClass() {
       // class for elements that need to be disabled
@@ -290,7 +277,7 @@ export default {
       // redirects to the dashboard page for the selected plio
       this.$router.push({
         name: "Dashboard",
-        params: { plioId: this.filteredData[rowIndex]["name"]["value"], org: this.org },
+        params: { plioId: this.localData[rowIndex]["name"]["value"], org: this.org },
       });
     },
     analyseButtonTooltip(rowIndex) {
@@ -301,7 +288,7 @@ export default {
     },
     isPublished(rowIndex) {
       // whether the plio in the given row is published
-      return this.filteredData[rowIndex]["name"]["status"] == "published";
+      return this.localData[rowIndex]["name"]["status"] == "published";
     },
     tableRowHoverOn(rowIndex) {
       // triggered upon hovering over a row
@@ -344,64 +331,25 @@ export default {
       // if a particular entry in the table is a component or not
       return value.type == "component";
     },
-    initialiseSortOrders() {
-      // initialise sorting orders for all table columns
-      // set it to 1 - ascending
-      const columnSortOrders = {};
-      this.columns.forEach(function (key) {
-        columnSortOrders[key] = 1;
-      });
-      this.sortOrders = columnSortOrders;
-    },
     capitalize(str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
-    },
-    sortBy(key) {
-      // invoked when sorting arrows are clicked on a table column
-      // sortOrder value can be 1(ascending) or -1(descending)
-      // everytime this method is involed, sortOrder for the "key" is toggled
-      this.sortKey = key;
-      this.sortOrders[key] = this.sortOrders[key] * -1;
     },
     savePlioDetails(rowIndex, plioDetails) {
       // save the plio's status after they are fetched from the PlioListItem
 
-      // Each plio's status is being stored in the filteredData object and that too,
+      // Each plio's status is being stored in the localData object and that too,
       // inside the "name" key as that key contains the details of plios
-      if (this.filteredData != undefined && this.filteredData[rowIndex] != undefined) {
-        this.filteredData[rowIndex]["name"] = {
-          ...this.filteredData[rowIndex]["name"],
+      if (this.localData != undefined && this.localData[rowIndex] != undefined) {
+        this.localData[rowIndex]["name"] = {
+          ...this.localData[rowIndex]["name"],
           ...plioDetails,
         };
       }
-    },
-    orderBySort(data) {
-      const sortKey = this.sortKey;
-      const order = this.sortOrders[sortKey];
-
-      if (sortKey) {
-        data = data.slice().sort(function (a, b) {
-          a = a[sortKey];
-          b = b[sortKey];
-          if (sortKey == "name") {
-            // to apply sorting on the plio title
-            a = a["title"].toLowerCase();
-            b = b["title"].toLowerCase();
-          }
-          return (a === b ? 0 : a > b ? 1 : -1) * order;
-        });
-      }
-      return data;
     },
     getColumnHeaderStyleClass(columnIndex) {
       return {
         "hidden sm:table-cell": !this.isFirstColumn(columnIndex),
         "sm:px-6 px-3": this.isFirstColumn(columnIndex),
-      };
-    },
-    getSortIconStyleClass(columnName) {
-      return {
-        "transform rotate-180": this.sortOrders[columnName] == -1,
       };
     },
     search() {

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -271,7 +271,6 @@ export default {
   methods: {
     ...mapActions("sync", ["startLoading"]),
     resetSearchString() {
-      console.log("Test");
       // starts loading and resets the search string
       this.startLoading();
       this.searchString = "";

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -63,6 +63,7 @@
                 <tr>
                   <th
                     v-for="(columnName, columnIndex) in columns"
+                    @click="sortBy(columnName)"
                     :key="columnName"
                     scope="col"
                     class="sm:py-3 py-1.5 text-left text-xs sm:text-md font-medium text-gray-500 uppercase tracking-wider w-2/3"
@@ -71,6 +72,13 @@
                     <div class="flex">
                       <div class="p-1 my-auto whitespace-nowrap md:text-base xl:text-lg">
                         {{ tableColumnName(columnName) }}
+                      </div>
+                      <div class="p-1 my-auto cursor-pointer">
+                        <inline-svg
+                          :src="require('@/assets/images/chevron-down-solid.svg')"
+                          class="h-3 w-3 my-1 transition ease duration-800"
+                          :class="getSortIconStyleClass(columnName)"
+                        ></inline-svg>
                       </div>
                     </div>
                   </th>
@@ -194,6 +202,8 @@ export default {
       // classes for search bar input box
       searchInputBoxClass:
         "w-full text-gray-700 leading-tight p-2 pl-4 focus:outline-none",
+      // sort order for the "number of viewers" column. 1 - ascending, -1 - descending
+      numberOfViewersSortOrder: 1,
     };
   },
 
@@ -260,6 +270,14 @@ export default {
   },
   methods: {
     ...mapActions("sync", ["startLoading"]),
+    sortBy(columnName) {
+      // toggle the sort order for "number_of_viewers" column
+      // and emit it to the parent (Home.vue)
+      if (columnName == "number_of_viewers") {
+        this.numberOfViewersSortOrder = this.numberOfViewersSortOrder * -1;
+        this.$emit("sort-by-number-of-viewers", this.numberOfViewersSortOrder);
+      }
+    },
     resetSearchString() {
       // starts loading and resets the search string
       this.startLoading();
@@ -352,12 +370,20 @@ export default {
         "sm:px-6 px-3": this.isFirstColumn(columnIndex),
       };
     },
+    getSortIconStyleClass(columnName) {
+      // flip the icon if sort order changes
+      // hide the icon for the "name" column
+      return {
+        "transform rotate-180": this.numberOfViewersSortOrder == -1,
+        hidden: columnName == "name",
+      };
+    },
     search() {
       // emit the search string whenever the user presses the search icon
       this.$emit("search-plios", { searchString: this.searchString });
     },
   },
 
-  emits: ["search-plios", "reset-search-string"],
+  emits: ["search-plios", "reset-search-string", "sort-by-number-of-viewers"],
 };
 </script>

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -270,14 +270,6 @@ export default {
   },
   methods: {
     ...mapActions("sync", ["startLoading"]),
-    sortBy(columnName) {
-      // toggle the sort order for "number_of_viewers" column
-      // and emit it to the parent (Home.vue)
-      if (columnName == "number_of_viewers") {
-        this.numberOfViewersSortOrder = this.numberOfViewersSortOrder * -1;
-        this.$emit("sort-by-number-of-viewers", this.numberOfViewersSortOrder);
-      }
-    },
     resetSearchString() {
       // starts loading and resets the search string
       this.startLoading();
@@ -351,6 +343,14 @@ export default {
     },
     capitalize(str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
+    },
+    sortBy(columnName) {
+      // toggle the sort order for "number_of_viewers" column
+      // and emit it to the parent (Home.vue)
+      if (columnName == "number_of_viewers") {
+        this.numberOfViewersSortOrder = this.numberOfViewersSortOrder * -1;
+        this.$emit("sort-by-number-of-viewers", this.numberOfViewersSortOrder);
+      }
     },
     savePlioDetails(rowIndex, plioDetails) {
       // save the plio's status after they are fetched from the PlioListItem

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -70,7 +70,9 @@
                     :class="getColumnHeaderStyleClass(columnIndex)"
                   >
                     <div class="flex">
-                      <div class="p-1 my-auto whitespace-nowrap md:text-base xl:text-lg">
+                      <div
+                        class="p-1 my-auto whitespace-nowrap md:text-base xl:text-lg cursor-pointer"
+                      >
                         {{ tableColumnName(columnName) }}
                       </div>
                       <div class="p-1 my-auto cursor-pointer">

--- a/src/components/Collections/Table/Table.vue
+++ b/src/components/Collections/Table/Table.vue
@@ -271,6 +271,7 @@ export default {
   methods: {
     ...mapActions("sync", ["startLoading"]),
     resetSearchString() {
+      console.log("Test");
       // starts loading and resets the search string
       this.startLoading();
       this.searchString = "";

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -162,6 +162,7 @@ export default {
       // fetch all the plios again
       if (this.searchString != "") {
         this.searchString = "";
+        await this.fetchPlioIds();
       }
     },
 

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -32,7 +32,7 @@
         :totalNumberOfPlios="totalNumberOfPlios"
         @search-plios="fetchPlioIds($event)"
         @reset-search-string="resetSearchString"
-        @sort-by-number-of-viewers="sortByNumberOfViewers"
+        @sort-num-viewers="sortPlios"
       >
       </Table>
 
@@ -113,7 +113,7 @@ export default {
       totalNumberOfPlios: 0, // total number of plios for the user
       numberOfPliosPerPage: 5, // number of plios to show on one page (default: 5)
       searchString: "", // the search string to filter the plios on
-      sortByFields: [], // array containing the fields to sort the plios on
+      sortByField: undefined, // string which holds the field to sort the plios on
       currentPageNumber: undefined, // holds the current page number
     };
   },
@@ -145,16 +145,9 @@ export default {
   methods: {
     ...mapActions("plioItems", ["purgeAllPlios"]),
     ...mapActions("sync", ["startLoading", "stopLoading"]),
-    async sortByNumberOfViewers(sortOrder) {
-      // invoked when the user clicks the sort icon next to "number of viewers" column
-
-      // remove any existing value of "unique_viewers" field. New value will be pushed below
-      this.sortByFields = this.sortByFields.filter((value) => {
-        return !value.includes("unique_viewers");
-      });
-
-      // push the appropriate field name according to the sort order and make the API call
-      this.sortByFields.push(sortOrder == 1 ? "unique_viewers" : "-unique_viewers");
+    async sortPlios(sortByField) {
+      // invoked when the user clicks the sort icon next to a column
+      this.sortByField = sortByField;
       await this.fetchPlioIds();
     },
     async resetSearchString() {
@@ -189,7 +182,7 @@ export default {
         uuidOnly,
         this.currentPageNumber,
         this.searchString,
-        this.sortByFields
+        this.sortByField
       )
         .then((response) => {
           // to handle the case when the user lands on the homepage for the first time

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -178,7 +178,6 @@ export default {
       // if the params contain a valid pageNumber, update the local currentPageNumber variable
       if (pageNumber != undefined) this.currentPageNumber = pageNumber;
 
-      console.log(this.sortByField);
       await PlioAPIService.getAllPlios(
         uuidOnly,
         this.currentPageNumber,

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -178,6 +178,7 @@ export default {
       // if the params contain a valid pageNumber, update the local currentPageNumber variable
       if (pageNumber != undefined) this.currentPageNumber = pageNumber;
 
+      console.log(this.sortByField);
       await PlioAPIService.getAllPlios(
         uuidOnly,
         this.currentPageNumber,

--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -55,7 +55,7 @@ export default {
     uuidOnly = false,
     pageNumber = undefined,
     searchString = "",
-    sortBy = []
+    sortBy = undefined
   ) {
     // returns all the plios (or just the flat list of uuids) created by the user
     // also fetches the plios at a given page number [if applicable]
@@ -70,7 +70,7 @@ export default {
     if (searchString != undefined && searchString != "")
       queryParams["search"] = searchString;
     // add sort by query param
-    if (sortBy.length != 0) queryParams["ordering"] = sortBy.join();
+    if (sortBy != undefined) queryParams["ordering"] = sortBy;
 
     return apiClient().get(url, { params: queryParams });
   },

--- a/src/services/API/Plio.js
+++ b/src/services/API/Plio.js
@@ -51,7 +51,12 @@ export default {
     });
   },
 
-  getAllPlios(uuidOnly = false, pageNumber = undefined, searchString = "") {
+  getAllPlios(
+    uuidOnly = false,
+    pageNumber = undefined,
+    searchString = "",
+    sortBy = []
+  ) {
     // returns all the plios (or just the flat list of uuids) created by the user
     // also fetches the plios at a given page number [if applicable]
     // also filters and fetches the plios that match the given search string [if applicable]
@@ -64,6 +69,8 @@ export default {
     // add search string query param
     if (searchString != undefined && searchString != "")
       queryParams["search"] = searchString;
+    // add sort by query param
+    if (sortBy.length != 0) queryParams["ordering"] = sortBy.join();
 
     return apiClient().get(url, { params: queryParams });
   },


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-frontend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-frontend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/v2/style-guide/#Priority-A-Rules-Essential-Error-Prevention.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #291 
Please see the issue linked for more details

## Summary
- user only sees the sorting arrow icon over "number of viewers" and not over "name" column
- user clicks the sorting button and a request to the backend is made asking for the ordered results in a paginated format

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [x] Responsive
- [x] Tested locally
- [x] Tested on staging
- [ ] Tested on production
