### PR TITLE
BigQuery optimizations

### DIFF
--- a/src/services/API/Queries/Plio.js
+++ b/src/services/API/Queries/Plio.js
@@ -29,16 +29,6 @@ export function dashboardSessionMetricsQuery(plioId) {
         operator: "equals",
         values: [plioId],
       },
-      {
-        member: "Plio.uuid",
-        operator: "equals",
-        values: [plioId],
-      },
-      {
-        member: "Plio.uuid",
-        operator: "equals",
-        values: [plioId],
-      },
     ],
   };
 }
@@ -53,16 +43,6 @@ export function dashboardSessionAnswerMetricsQuery(plioId) {
       "AggregateSessionMetrics.accuracy",
     ],
     filters: [
-      {
-        member: "Plio.uuid",
-        operator: "equals",
-        values: [plioId],
-      },
-      {
-        member: "Plio.uuid",
-        operator: "equals",
-        values: [plioId],
-      },
       {
         member: "Plio.uuid",
         operator: "equals",


### PR DESCRIPTION
## Summary

WHERE clause optimizations for BigQuery. Removed redundant filters that was causing consecutive where statements with same checks.
<img width="1353" alt="Screenshot 2021-06-14 at 5 40 59 PM" src="https://user-images.githubusercontent.com/12053186/121890416-f27b6300-cd37-11eb-9c07-593fcb077393.png">


## Test Plan
- [x] Tested locally
- [x] Tested on staging
- [ ] Tested on production
