### PR TITLE
Full screen error fix

### DIFF
--- a/src/pages/Player.vue
+++ b/src/pages/Player.vue
@@ -229,8 +229,20 @@ export default {
   watch: {
     isFullscreen(newIsFullscreen) {
       // track the fullscreen status
-      if (newIsFullscreen) this.player.fullscreen.enter();
-      else this.player.fullscreen.exit();
+
+      if (newIsFullscreen) {
+        // trigger player fullscreen enter only if it is not already entered full screen
+        // by other modes like player controls or double click on the video.
+        if (!this.player.fullscreen.active) {
+          this.player.fullscreen.enter();
+        }
+      } else {
+        // trigger player full screen exit only if it is not already exited full screen
+        // by other modes like player controls or double click on the video.
+        if (this.player.fullscreen.active) {
+          this.player.fullscreen.exit();
+        }
+      }
     },
   },
   async created() {


### PR DESCRIPTION
Fixes #405 

## Summary

- Fullscreen can be triggered by multiple controls. The error comes up when we try to enter/exit fullscreen from player controls.
- Because player controls have already triggered fullscreen action, after that, it also triggers the variable `isFullscreen` update which then again triggers the fullscreen action.
- Added proper checks to avoid re-triggering of fullscreen actions if they're already triggered by player controls. 

## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [ ] Test Responsiveness
   - [ ] Laptop (1200px)
   - [ ] Tablet (760px)
   - [ ] Phone (320px)
- [ ] Cross-Browser Testing
   - [ ] Chrome
   - [ ] Firefox
   - [ ] Safari
- [ ] Local Language Support
- [ ] Wrote tests
- [x] Tested locally
- [ ] Tested on staging
- [ ] Tested on an actual physical phone
- [ ] Tested on production
- [ ] Check for bundle size [here](https://bundlephobia.com/) if adding a package
- [ ] Added relevant details like Labels/Projects/Milestones etc.
