### PR TITLE
FIX: better reauthentication logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -146,9 +146,9 @@ export default {
   },
   async created() {
     // whenever the app is set up (on a fresh page load)
-    // reset the re authentication state. This is required because if in the
-    // previous run, if the user exited while the re authentication was in process,
-    // the re authentication state is set as `in-process` in the store and the next
+    // reset the reAuthenticationState. This is required because if in the
+    // previous run, if the user exited while the re-authentication was in process,
+    // the reAuthenticationState is set as `in-process` in the store and the next
     // time user reloads, the value will remain the same
     this.setReAuthenticationState("not-started");
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -145,6 +145,13 @@ export default {
     };
   },
   async created() {
+    // whenever the app is set up (on a fresh page load)
+    // reset the re authentication state. This is required because if in the
+    // previous run, if the user exited while the re authentication was in process,
+    // the re authentication state is set as `in-process` in the store and the next
+    // time user reloads, the value will remain the same
+    this.setReAuthenticationState("not-started");
+
     // reset the value of pending while creating the component
     if (this.pending) this.stopLoading();
     // reset the value of whether background is disabled
@@ -247,6 +254,7 @@ export default {
       "unsetAccessToken",
       "fetchAndUpdateUser",
       "unsetActiveWorkspace",
+      "setReAuthenticationState",
     ]),
     ...mapActions("generic", [
       "unsetSharePlioDialog",

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -53,7 +53,7 @@ client.interceptors.request.use(
 client.interceptors.response.use(
   (config) => {
     // reset reAuthenticationState to its original value whenever any request returns
-    // a non error response code. Make sure not to do this for refresh token call
+    // a non-error response code. Make sure not to do this for refresh token call
     if (config.config.url != refreshTokenEndpoint)
       store.dispatch("auth/setReAuthenticationState", "not-started");
     return config;

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -133,7 +133,7 @@ client.interceptors.response.use(
       // the reason why we're not using the above try/catch logic as it as and why
       // we're wrapping it into an async function
       // https://itnext.io/error-handling-with-async-await-in-js-26c3f20bc06a
-      return run();
+      return handleReAuthentication();
     }
 
     ErrorHandling.handleAPIErrors(error);

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -81,7 +81,7 @@ client.interceptors.response.use(
 
     // Handle expired/deleted access token here
     if (status === 401) {
-      // reAuthenticate the user if this is the first reAuthentication call. While reAuthentication is going on
+      // re-authenticate the user if this is the first re-authentication call. While re-authentication is going on
       // if some other request ends up here, then wait for the reAuthentication process to finish. Once that is done,
       // set the newly retrieved access token as an auth header and retry the request. Any errors in the reauthentication
       // process are caught and the user is logged out.

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -13,6 +13,12 @@ let headers = {
   "Content-Type": "application/json",
 };
 
+// whenever the RootClient is set up (on a fresh page load)
+// reset the re authentication state. This is required because if in the
+// previous run, if the user exited while the re authentication was in process,
+// the re authentication state is set as `in-process` in the store
+store.dispatch("auth/setReAuthenticationState", "not-started");
+
 // backend API client
 const client = axios.create({
   baseURL: process.env.VUE_APP_BACKEND,

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -95,17 +95,15 @@ client.interceptors.response.use(
                 "Re-authentication failed, no more calls allowed"
               );
             case "in-process":
-              // re authentication process in progress. Wait for the promise to resolve,
-              // then proceed
+              // re-authentication process in progress. Wait for the promise to resolve,
               await store.state.auth.reAuthenticationPromise;
               break;
             case "not-started":
-              // fresh re authentication process to begin now. Wait for the process to complete,
-              // then proceed
+              // fresh re-authentication process to begin now. Wait for the process to complete,
               await UserFunctionalService.reAuthenticate(store);
               break;
           }
-          // Add the new access token recieved from the re authentication process
+          // Add the new access token recieved from the re-authentication process
           // to the header of the request and retry the request
           let newAccessToken = store.state.auth.accessToken.access_token;
           error.config.headers["Authorization"] = `Bearer ${newAccessToken}`;
@@ -116,8 +114,8 @@ client.interceptors.response.use(
           }
           return client.request(error.config); // retrying the request
         } catch (err) {
-          // an error occured in the re authentication process
-          // reset the reAuthenticationState value, so any future reAuthentication processes
+          // an error occured in the re-authentication process
+          // reset the reAuthenticationState value, so any future re-authentication processes
           // can function normally
           store.dispatch("auth/setReAuthenticationState", "not-started");
           // if the user is still logged in, log them out

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -90,7 +90,7 @@ client.interceptors.response.use(
           let reAuthenticationState = store.state.auth.reAuthenticationState;
           switch (reAuthenticationState) {
             case "dropped":
-              // re authentication process was dropped, throw an error.
+              // re-authentication process was dropped, throw an error.
               throw new Error(
                 "Re-authentication failed, no more calls allowed"
               );

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -54,7 +54,7 @@ client.interceptors.response.use(
   (config) => {
     // reset reAuthenticationState to its original value whenever any request returns
     // a non-error response code. Make sure not to do this for refresh token call
-    if (config.config.url != refreshTokenEndpoint)
+    if (config.config.url != refreshTokenEndpoint && store.state.auth.reAuthenticationState != "not-started")
       store.dispatch("auth/setReAuthenticationState", "not-started");
     return config;
   },

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -82,7 +82,7 @@ client.interceptors.response.use(
     // Handle expired/deleted access token here
     if (status === 401) {
       // re-authenticate the user if this is the first re-authentication call. While re-authentication is going on
-      // if some other request ends up here, then wait for the reAuthentication process to finish. Once that is done,
+      // if some other request ends up here, then wait for the re-authentication process to finish. Once that is done,
       // set the newly retrieved access token as an auth header and retry the request. Any errors in the reauthentication
       // process are caught and the user is logged out.
       let run = async () => {

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -85,7 +85,7 @@ client.interceptors.response.use(
       // if some other request ends up here, then wait for the re-authentication process to finish. Once that is done,
       // set the newly retrieved access token as an auth header and retry the request. Any errors in the re-authentication
       // process are caught and the user is logged out.
-      let run = async () => {
+      let handleReAuthentication = async () => {
         try {
           let reAuthenticationState = store.state.auth.reAuthenticationState;
           switch (reAuthenticationState) {

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -13,12 +13,6 @@ let headers = {
   "Content-Type": "application/json",
 };
 
-// whenever the RootClient is set up (on a fresh page load)
-// reset the re authentication state. This is required because if in the
-// previous run, if the user exited while the re authentication was in process,
-// the re authentication state is set as `in-process` in the store
-store.dispatch("auth/setReAuthenticationState", "not-started");
-
 // backend API client
 const client = axios.create({
   baseURL: process.env.VUE_APP_BACKEND,

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -52,7 +52,7 @@ client.interceptors.request.use(
 // handle errors in responses for API requests
 client.interceptors.response.use(
   (config) => {
-    // reset reAuthenticationState to it's original value whenever any request returns
+    // reset reAuthenticationState to its original value whenever any request returns
     // a non error response code. Make sure not to do this for refresh token call
     if (config.config.url != refreshTokenEndpoint)
       store.dispatch("auth/setReAuthenticationState", "not-started");

--- a/src/services/API/RootClient.js
+++ b/src/services/API/RootClient.js
@@ -83,7 +83,7 @@ client.interceptors.response.use(
     if (status === 401) {
       // re-authenticate the user if this is the first re-authentication call. While re-authentication is going on
       // if some other request ends up here, then wait for the re-authentication process to finish. Once that is done,
-      // set the newly retrieved access token as an auth header and retry the request. Any errors in the reauthentication
+      // set the newly retrieved access token as an auth header and retry the request. Any errors in the re-authentication
       // process are caught and the user is logged out.
       let run = async () => {
         try {

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -33,7 +33,7 @@ export default {
       }
     } catch (e) {
       // an error occured in the process of refreshing the access token.
-      // We'll mark the re authentication process as dropped and throw an error
+      // We'll mark the re-authentication process as dropped and throw an error
       store.dispatch("auth/setReAuthenticationState", "dropped");
       throw new Error(e);
     }

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -23,7 +23,7 @@ export default {
       let response = await UserAPIService.refreshAccessToken();
       if (response != undefined && response.data != undefined) {
         // set the recieved access token into the store
-        // and mark the re authentication process as completed.
+        // and mark the re-authentication process as completed.
         // We will also resolve the pending reAuthenticationPromise so the code
         // that is waiting for the promises to resolve can proceed
         store.dispatch("auth/setAccessToken", response.data);

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -11,7 +11,7 @@ export default {
       reAuthenticationPromiseResolver = resolve;
     });
 
-    // save the above created promise and it's resolver into the store
+    // save the above created promise and its resolver into the store
     store.dispatch("auth/setReAuthenticationPromise", reAuthenticationPromise);
     store.dispatch(
       "auth/setReAuthenticationPromiseResolver",

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -2,7 +2,7 @@ import UserAPIService from "@/services/API/User.js";
 
 export default {
   async reAuthenticate(store) {
-    // set re Authentication state as in progress
+    // set reAuthentication state as in progress
     store.dispatch("auth/setReAuthenticationState", "in-process");
 
     // create a promise and store it's resolver in a separate variable

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -5,7 +5,7 @@ export default {
     // set reAuthentication state as in progress
     store.dispatch("auth/setReAuthenticationState", "in-process");
 
-    // create a promise and store it's resolver in a separate variable
+    // create a promise and store its resolver in a separate variable
     let reAuthenticationPromiseResolver;
     let reAuthenticationPromise = new Promise((resolve) => {
       reAuthenticationPromiseResolver = resolve;

--- a/src/services/Functional/User.js
+++ b/src/services/Functional/User.js
@@ -2,7 +2,7 @@ import UserAPIService from "@/services/API/User.js";
 
 export default {
   async reAuthenticate(store) {
-    // set reAuthentication state as in progress
+    // set re-authentication state as in progress
     store.dispatch("auth/setReAuthenticationState", "in-process");
 
     // create a promise and store its resolver in a separate variable

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -67,37 +67,37 @@ const getters = {
 
 const actions = {
   async setAccessToken({ commit, dispatch }, accessToken) {
-    await commit("setAccessToken", accessToken);
+    commit("setAccessToken", accessToken);
     await dispatch("fetchAndUpdateUser");
   },
-  async unsetAccessToken({ commit, dispatch }) {
-    await commit("unsetAccessToken");
+  unsetAccessToken({ commit, dispatch }) {
+    commit("unsetAccessToken");
     dispatch("unsetUser");
     dispatch("unsetAnalyticsAccessToken");
   },
-  async setUser({ commit }, user) {
-    await commit("setUser", user);
+  setUser({ commit }, user) {
+    commit("setUser", user);
   },
-  async unsetUser({ commit }) {
-    await commit("unsetUser");
+  unsetUser({ commit }) {
+    commit("unsetUser");
   },
-  async setActiveWorkspace({ commit }, activeWorkspace) {
-    await commit("setActiveWorkspace", activeWorkspace);
+  setActiveWorkspace({ commit }, activeWorkspace) {
+    commit("setActiveWorkspace", activeWorkspace);
   },
-  async unsetActiveWorkspace({ commit }) {
-    await commit("unsetActiveWorkspace");
+  unsetActiveWorkspace({ commit }) {
+    commit("unsetActiveWorkspace");
   },
-  async saveConfig({ commit }, config) {
-    await commit("saveConfig", config);
+  saveConfig({ commit }, config) {
+    commit("saveConfig", config);
   },
-  async setReAuthenticationState({ commit }, state) {
-    await commit("setReAuthenticationState", state);
+  setReAuthenticationState({ commit }, state) {
+    commit("setReAuthenticationState", state);
   },
-  async setReAuthenticationPromise({ commit }, promise) {
-    await commit("setReAuthenticationPromise", promise);
+  setReAuthenticationPromise({ commit }, promise) {
+    commit("setReAuthenticationPromise", promise);
   },
-  async setReAuthenticationPromiseResolver({ commit }, resolver) {
-    await commit("setReAuthenticationPromiseResolver", resolver);
+  setReAuthenticationPromiseResolver({ commit }, resolver) {
+    commit("setReAuthenticationPromiseResolver", resolver);
   },
   updateUserStatus({ commit }, status) {
     commit("updateUserStatus", status);
@@ -106,7 +106,7 @@ const actions = {
     let response = await UserAPIService.getUserByAccessToken(
       state.accessToken.access_token
     );
-    if (response != undefined) await dispatch("setUser", response.data);
+    if (response != undefined) dispatch("setUser", response.data);
   },
   async getAnalyticsAccessToken({ commit }) {
     let response = await AnalyticsAPIService.getAnalyticsAccessToken();
@@ -115,8 +115,8 @@ const actions = {
   unsetAnalyticsAccessToken({ commit }) {
     commit("unsetAnalyticsAccessToken");
   },
-  async autoLogoutUser({ dispatch }) {
-    await dispatch("unsetAccessToken");
+  autoLogoutUser({ dispatch }) {
+    dispatch("unsetAccessToken");
   },
 };
 

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -8,8 +8,9 @@ const state = {
   user: null,
   activeWorkspace: "",
   userId: null,
-  isReAuthenticating: false,
+  reAuthenticationState: "not-started",
   reAuthenticationPromise: null,
+  reAuthenticationPromiseResolver: null,
   analyticsAccessToken: null,
   analyticsAccessTokenFetchTime: null,
   analyticsAccessTokenExpiryTime: null,
@@ -89,14 +90,14 @@ const actions = {
   async saveConfig({ commit }, config) {
     await commit("saveConfig", config);
   },
-  setReAuthenticationState({ commit }, isReAuthenticating) {
-    commit("setReAuthenticationState", isReAuthenticating);
+  async setReAuthenticationState({ commit }, state) {
+    await commit("setReAuthenticationState", state);
   },
-  setReAuthenticationPromise({ commit }, reAuthenticationPromise) {
-    commit("setReAuthenticationPromise", reAuthenticationPromise);
+  async setReAuthenticationPromise({ commit }, promise) {
+    await commit("setReAuthenticationPromise", promise);
   },
-  unsetReAuthenticationPromise({ commit }) {
-    commit("unsetReAuthenticationPromise");
+  async setReAuthenticationPromiseResolver({ commit }, resolver) {
+    await commit("setReAuthenticationPromiseResolver", resolver);
   },
   updateUserStatus({ commit }, status) {
     commit("updateUserStatus", status);
@@ -105,7 +106,7 @@ const actions = {
     let response = await UserAPIService.getUserByAccessToken(
       state.accessToken.access_token
     );
-    if (response != undefined) dispatch("setUser", response.data);
+    if (response != undefined) await dispatch("setUser", response.data);
   },
   async getAnalyticsAccessToken({ commit }) {
     let response = await AnalyticsAPIService.getAnalyticsAccessToken();
@@ -116,7 +117,6 @@ const actions = {
   },
   async autoLogoutUser({ dispatch }) {
     await dispatch("unsetAccessToken");
-    await dispatch("setReAuthenticationState", false);
   },
 };
 
@@ -144,14 +144,14 @@ const mutations = {
   saveConfig(state, config) {
     state.config = config;
   },
-  setReAuthenticationState(state, isReAuthenticating) {
-    state.isReAuthenticating = isReAuthenticating;
+  setReAuthenticationState(state, reAuthenticationState) {
+    state.reAuthenticationState = reAuthenticationState;
   },
-  setReAuthenticationPromise(state, reAuthenticationPromise) {
-    state.reAuthenticationPromise = reAuthenticationPromise;
+  setReAuthenticationPromise(state, promise) {
+    state.reAuthenticationPromise = promise;
   },
-  unsetReAuthenticationPromise(state) {
-    state.reAuthenticationPromise = null;
+  setReAuthenticationPromiseResolver(state, resolver) {
+    state.reAuthenticationPromiseResolver = resolver;
   },
   updateUserStatus(state, status) {
     state.user.status = status;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-frontend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-frontend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/v2/style-guide/#Priority-A-Rules-Essential-Error-Prevention.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #508 

## Solution
- Make sure you read the issue before going through the given solution
- Getting rid of the old store variable `isReauthenticating`
- Using a new store variable called `reAuthenticationState`. This store variable can have the below possible values
   -  `not-started` - This means that the re authentication process has not yet started or the process has finished and all the subsequent calls are now using the new refreshed access token
   - `in-process` - This means that currently a re authentication process is going on. 
   - `completed` - This means that a re authentication process was going on, and is now completed. All the pending requests that need a new access token can just use it and retry requesting again
   - `dropped` - This means that a re authentication process was started, but something went wrong and re authentication was not possible.
- Re using the store variable `reAuthenticationPromise`
- Using a new store variable called `reAuthenticationPromiseResolver` whose job is to resolve the `reAuthenticationPromise`.
- This is how the logic looks like
    - Whenever a request's response returns a 401 error, the code checks the value of `reAuthenticationState`
    - If `reAuthenticationState` is not started, then the method `UserFunctionalService.reAuthenticate(store)` is called
        - Inside the `reAuthenticate` method, we change the value of `reAuthenticationState` to `in-process`
        - We also create a promise, save it into the store. 
        - We also expose the resolver of the above promise and save it into the store as well. What this will allow us to do is we can wait for the promise somewhere else and resolve it from somewhere else.
        - Then we try to refresh the access token, and if we get a successful response, we store the access token into the store
        - we then set the `reAuthenticationState` to `completed`
        - we then resolve the `reAuthenticationPromise` - Why we do this, I'll explain later on
        - If there's some error while refreshing the access token, we throw an error (which will be caught at the callee - `RootClient.js`) and we set `reAuthenticationState` as `dropped`
    - If `reAuthenticationState` is `in-process`, then we need to wait for the process to complete. So we'll await the `reAuthenticationPromise` to fulfill. When the promise is resolved from inside the `UserFunctionalService.reAuthenticate(store)` method, then this await will resolve and we will move forward
    - If `reAuthenticationState` is `dropped`, then we throw an error. We will reset the `reAuthenticationState` to `not-started` so future re authentication processes can work correctly.


<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- ~[ ] Test Responsiveness~
   - [ ] Laptop (1200px)
   - [ ] Tablet (760px)
   - [ ] Phone (320px)
- ~[ ] Cross-Browser Testing~
   - [ ] Chrome
   - [ ] Firefox
   - [ ] Safari (use BrowserStack)
- ~[ ] Local Language Support~
- [ ] Wrote tests
- [x] Tested locally
- [x] Self-review
- [x] Comments have been added appropriately
- ~[ ] Check for bundle size [here](https://bundlephobia.com/) if adding a package~
- [x] Added relevant details like Labels/Projects/Milestones etc.
- ~[ ] Images have `alt` attributes~
- ~[ ] Any `target="_blank"` links have `rel="noopener"`~
- ~[ ] Only SVGs are used as images. If PNGs are used, their size has been optimised.~
- [ ] Tested on staging
- ~[ ] Tested on an actual physical phone~
- [ ] Tested on production
