### PR TITLE
Prevents viewer from using the video seekbar to skip questions when skip disabled

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ module.exports = {
   presets: ["@vue/cli-plugin-babel/preset"],
   env: {
     production: {
-      plugins: ["transform-remove-console"],
+      plugins: [],
     },
     development: {
       plugins: [

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ module.exports = {
   presets: ["@vue/cli-plugin-babel/preset"],
   env: {
     production: {
-      plugins: [],
+      plugins: ["transform-remove-console"],
     },
     development: {
       plugins: [

--- a/src/assets/locales/en.js
+++ b/src/assets/locales/en.js
@@ -628,5 +628,9 @@ export default {
         },
       },
     },
+    player: {
+      cannot_skip_interaction:
+        "You have to answer this question before moving ahead",
+    },
   },
 };

--- a/src/assets/locales/en.js
+++ b/src/assets/locales/en.js
@@ -629,8 +629,7 @@ export default {
       },
     },
     player: {
-      cannot_skip_interaction:
-        "You have to answer this question before moving ahead",
+      cannot_skip_item: "You have to answer this question before moving ahead",
     },
   },
 };

--- a/src/assets/locales/hi.js
+++ b/src/assets/locales/hi.js
@@ -631,8 +631,7 @@ export default {
       },
     },
     player: {
-      cannot_skip_interaction:
-        "आगे बढ़ने से पहले आपको इस सवाल का जवाब देना होगा",
+      cannot_skip_item: "आगे बढ़ने से पहले आपको इस सवाल का जवाब देना होगा",
     },
   },
 };

--- a/src/assets/locales/hi.js
+++ b/src/assets/locales/hi.js
@@ -630,5 +630,9 @@ export default {
         },
       },
     },
+    player: {
+      cannot_skip_interaction:
+        "आगे बढ़ने से पहले आपको इस सवाल का जवाब देना होगा",
+    },
   },
 };

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -930,12 +930,16 @@ export default {
       return linkValidation["ID"];
     },
     playerPlayed() {
+      console.log(this.player.playing);
+      console.log(this.isSkipEnabled);
+      console.log(this.isAnyItemActive);
       // invoked when the play button of the player is clicked
       if (this.isScorecardShown || (!this.isSkipEnabled && this.isAnyItemActive)) {
         /**
          * prevents the video from playing while the
          * scorecard is being shown or when an item is active with skip disabled
          */
+        console.log("yolo");
         this.pausePlayer();
         return;
       }

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -343,12 +343,7 @@ export default {
     ...mapGetters('auth', ['isAuthenticated']),
     ...mapState('generic', ['windowInnerWidth', 'windowInnerHeight']),
     firstUnansweredItem() {
-      if (
-        this.skipEnabled ||
-        this.lastAnsweredItemIndex == -1 ||
-        this.lastAnsweredItemIndex == this.numItems - 1
-      )
-        return null
+      if (this.skipEnabled || this.lastAnsweredItemIndex == this.numItems - 1) return null
       return this.items[this.lastAnsweredItemIndex + 1]
     },
     currentItem() {
@@ -919,15 +914,17 @@ export default {
           if (this.isItemMCQ(itemIndex)) {
             itemResponse.answer = parseInt(itemResponse.answer)
           }
-          if (
-            !this.isItemResponseEmpty(itemIndex, itemResponse.answer) &&
-            !this.isSkipEnabled
-          ) {
-            this.lastAnsweredItemIndex = itemIndex
-          }
           this.itemResponses.push(itemResponse)
         })
         if (!this.isSkipEnabled) {
+          // set the last answered item index
+          for (let [itemIndex, itemResponse] of this.itemResponses.entries()) {
+            if (!this.isItemResponseEmpty(itemIndex, itemResponse.answer))
+              this.lastAnsweredItemIndex = itemIndex
+            // https://github.com/avantifellows/plio-frontend/pull/629#issuecomment-1053819610
+            else break
+          }
+
           // check if any item before the current timestamp is unanswered
           // if there is, then update the timestamp to just before the
           // unanswered item

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -477,7 +477,7 @@ export default {
      * whether there are any items
      */
     hasAnyItems() {
-      return this.items.length != 0;
+      return this.numItems != 0;
     },
     /**
      * whether any item is currently active
@@ -578,6 +578,7 @@ export default {
      * Show the scorecard on top of the player
      */
     popupScorecard() {
+      if (this.checkMovingToTimestampAllowed(this.player.duration) != null) return;
       if (!this.isScorecardShown) {
         this.isScorecardShown = true;
         var scorecardModal = document.getElementById("scorecardmodal");
@@ -773,7 +774,7 @@ export default {
           this.itemDetails = plioDetails.itemDetails || [];
           // setting numSkipped to number of items. This value will keep reducing
           // as numCorrect and numWrong are calculated
-          this.numSkipped = this.items.length;
+          this.numSkipped = this.numItems;
           this.plioDBId = plioDetails.plioDBId;
           this.videoId = this.getVideoIDfromURL(plioDetails.videoURL);
           this.plioTitle = plioDetails.plioTitle;
@@ -961,7 +962,7 @@ export default {
       this.$mixpanel.track("Visit Player", {
         "Plio UUID": this.plioId,
         "Plio Video Length": this.player.duration || 0,
-        "Plio Num Items": this.items.length || 0,
+        "Plio Num Items": this.numItems || 0,
       });
       // sets various properties based on the screen size
       this.setScreenProperties();

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -129,7 +129,7 @@ export default {
     VideoSkeleton,
     ItemModal,
     IconButton,
-    Scorecard
+    Scorecard,
   },
   data() {
     return {
@@ -142,18 +142,18 @@ export default {
           "mute",
           "volume",
           "fullscreen",
-          "settings"
+          "settings",
         ],
 
         keyboard: {
           focused: false,
-          global: false
+          global: false,
         },
 
         hideControls: false,
         clickToPlay: false,
 
-        invertTime: false
+        invertTime: false,
       },
       videoId: "", // video Id for the Plio
       componentProperties: {}, // properties of the plio player
@@ -176,7 +176,7 @@ export default {
         "px-1",
         "bottom-full",
         "pointer-events-none",
-        "rounded-md"
+        "rounded-md",
       ],
       scorecardMarkerClass: [
         "absolute",
@@ -187,7 +187,7 @@ export default {
         "translate-y-6",
         "bottom-full",
         "pointer-events-none",
-        "text-2xl"
+        "text-2xl",
       ],
       lastCheckTimestamp: 0, // time in milliseconds when the last check for item pop-up took place
       isFullscreen: false, // is the player in fullscreen
@@ -210,7 +210,7 @@ export default {
       watchingEventDBId: null, // the DB id of the latest 'watching' event for a given session
       plioSettings: null, // stores this plio's settings
       lastAnsweredItemIndex: -1, // index of the interaction that was last answered
-      showItemPopUpErrorToast: false // whether to show the error toast when an item is opened
+      showItemPopUpErrorToast: false, // whether to show the error toast when an item is opened
     };
   },
   watch: {
@@ -247,8 +247,8 @@ export default {
           this.showItemMarkersOnSlider();
         }
       },
-      deep: true
-    }
+      deep: true,
+    },
   },
   async created() {
     // Creating a promise for the third party auth functionality.
@@ -266,7 +266,7 @@ export default {
       // and set the user accordingly
       UserAPIService.generateExternalAuthToken({
         unique_id: this.thirdPartyUniqueId,
-        api_key: this.thirdPartyApiKey
+        api_key: this.thirdPartyApiKey,
       })
         .then(async (response) => {
           await this.setAccessToken(response.data);
@@ -286,8 +286,8 @@ export default {
               name: "Player",
               params: {
                 workspace: this.workspace,
-                plioId: this.plioId
-              }
+                plioId: this.plioId,
+              },
             });
             thirdPartyAuthPromiseResolve();
           } else this.$router.replace({ name: "404" });
@@ -314,19 +314,19 @@ export default {
   props: {
     plioId: {
       default: "",
-      type: String
+      type: String,
     },
     workspace: {
       default: "",
-      type: String
+      type: String,
     },
     thirdPartyUniqueId: {
       default: null,
-      type: String
+      type: String,
     },
     thirdPartyApiKey: {
       default: null,
-      type: String
+      type: String,
     },
     /**
      * whether it is being opened in preview mode
@@ -334,15 +334,15 @@ export default {
      */
     previewMode: {
       default: false,
-      type: Boolean
+      type: Boolean,
     },
     /**
      * custom classes for the plio container
      */
     containerClass: {
       default: "h-screen",
-      type: String
-    }
+      type: String,
+    },
   },
   computed: {
     ...mapGetters("auth", ["isAuthenticated"]),
@@ -432,26 +432,26 @@ export default {
           name: this.$t("player.scorecard.metric.description.correct"),
           icon: {
             source: "check.svg",
-            class: "text-green-500"
+            class: "text-green-500",
           },
-          value: this.numCorrect
+          value: this.numCorrect,
         },
         {
           name: this.$t("player.scorecard.metric.description.wrong"),
           icon: {
             source: "times-solid.svg",
-            class: "text-red-500"
+            class: "text-red-500",
           },
-          value: this.numWrong
+          value: this.numWrong,
         },
         {
           name: this.$t("player.scorecard.metric.description.skipped"),
           icon: {
             source: "skip.svg",
-            class: "text-yellow-700"
+            class: "text-yellow-700",
           },
-          value: this.numSkipped
-        }
+          value: this.numSkipped,
+        },
       ];
     },
     /**
@@ -481,7 +481,7 @@ export default {
         value: this.isModalMinimized
           ? this.$t(`editor.buttons.show_${this.currentItemType}`)
           : this.$t("editor.buttons.show_video"),
-        class: "text-white text-md sm:text-base lg:text-xl font-bold"
+        class: "text-white text-md sm:text-base lg:text-xl font-bold",
       };
     },
     /**
@@ -532,7 +532,7 @@ export default {
     fullscreenButtonTitleConfig() {
       return {
         value: this.$t("player.fullscreen.enter"),
-        class: "text-white text-lg font-bold"
+        class: "text-white text-lg font-bold",
       };
     },
     /**
@@ -540,7 +540,7 @@ export default {
      */
     fullscreenButtonClass() {
       return `ring-2 ring-red-100 bg-primary hover:bg-primary-hover p-4 rounded-md shadow-xl place-self-center animate-bounce m-auto`;
-    }
+    },
   },
   methods: {
     ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
@@ -745,14 +745,14 @@ export default {
     videoSeeked() {
       // invoked when a seek operation ends
       this.createEvent("video_seeked", {
-        currentTime: this.player.currentTime
+        currentTime: this.player.currentTime,
       });
     },
     optionSelected(optionIndex) {
       // invoked when an option of a question is selected
       this.createEvent("option_selected", {
         itemIndex: this.currentItemIndex,
-        optionIndex: optionIndex
+        optionIndex: optionIndex,
       });
     },
     reviseQuestion() {
@@ -766,7 +766,7 @@ export default {
             POP_UP_PRECISION_TIME / 1000;
       // create an event for the revise action
       this.createEvent("question_revised", {
-        itemIndex: this.currentItemIndex
+        itemIndex: this.currentItemIndex,
       });
       this.closeItemModal();
     },
@@ -785,7 +785,7 @@ export default {
         // create an event for the submit action
         this.createEvent("question_answered", {
           itemIndex: this.currentItemIndex,
-          answer: itemResponse.answer
+          answer: itemResponse.answer,
         });
       }
 
@@ -804,14 +804,14 @@ export default {
       // invoked when the user skips the question
       this.closeItemModal();
       this.createEvent("question_skipped", {
-        itemIndex: this.currentItemIndex
+        itemIndex: this.currentItemIndex,
       });
     },
     proceedQuestion() {
       // invoked when the user has answered the question and wishes to proceed
       this.closeItemModal();
       this.createEvent("question_proceed", {
-        itemIndex: this.currentItemIndex
+        itemIndex: this.currentItemIndex,
       });
     },
     /**
@@ -894,11 +894,11 @@ export default {
         this.items.forEach((_, itemIndex) => {
           if (this.isItemMCQ(itemIndex)) {
             this.itemResponses.push({
-              answer: NaN
+              answer: NaN,
             });
           } else {
             this.itemResponses.push({
-              answer: null
+              answer: null,
             });
           }
         });
@@ -973,7 +973,7 @@ export default {
       return SessionAPIService.updateSession(this.sessionDBId, {
         plio: this.plioDBId,
         watch_time: this.watchTime,
-        retention: this.retentionArrayToStr(this.retention)
+        retention: this.retentionArrayToStr(this.retention),
       }).catch((err) => console.log(err));
     },
     retentionStrToArray(retentionStr) {
@@ -1034,7 +1034,7 @@ export default {
       this.$mixpanel.track("Visit Player", {
         "Plio UUID": this.plioId,
         "Plio Video Length": this.player.duration || 0,
-        "Plio Num Items": this.numItems || 0
+        "Plio Num Items": this.numItems || 0,
       });
       // sets various properties based on the screen size
       this.setScreenProperties();
@@ -1189,7 +1189,7 @@ export default {
         if (this.showItemPopUpErrorToast) {
           this.toast.error(`☝️ ${this.$t("toast.player.cannot_skip_item")}`, {
             id: "cannotSkipItem",
-            position: "bottom-center"
+            position: "bottom-center",
           });
           this.showItemPopUpErrorToast = false;
         }
@@ -1252,7 +1252,7 @@ export default {
         details: eventDetails,
         player_time:
           this.player.currentTime != null ? this.player.currentTime : 0,
-        session: this.sessionDBId
+        session: this.sessionDBId,
       });
       if (eventType == "watching") this.watchingEventDBId = response.id;
     },
@@ -1268,14 +1268,14 @@ export default {
         details: eventDetails,
         player_time:
           this.player.currentTime != null ? this.player.currentTime : 0,
-        session: this.sessionDBId
+        session: this.sessionDBId,
       });
     },
     goFullscreen() {
       this.isFullscreen = true;
-    }
+    },
   },
-  emits: ["initiated", "loaded", "item-toggle"]
+  emits: ["initiated", "loaded", "item-toggle"],
 };
 </script>
 

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -696,6 +696,7 @@ export default {
       }
     },
     moveToFirstUnansweredItemTimestampOrPass() {
+      if (this.isSkipEnabled) return false;
       let timeToInspect = this.player.currentTime;
 
       if (
@@ -918,6 +919,9 @@ export default {
           const firstUnansweredInteraction = this.checkMovingToTimestampAllowed(
             this.currentTimestamp
           );
+          // check if any item before the current timestamp is unanswered
+          // if there is, then update the timestamp to just before the
+          // unanswered item
           if (firstUnansweredInteraction != null) {
             this.currentTimestamp =
               firstUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -696,8 +696,6 @@ export default {
       }
     },
     moveToFirstUnansweredItemTimestampOrPass() {
-      let playerProgress = document.getElementsByClassName("plyr__progress__buffer")[0];
-      console.log(playerProgress.getAttribute("value"));
       let timeToInspect = this.player.currentTime;
 
       if (

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -2,7 +2,11 @@
   <div :id="plioContainerId">
     <!-- skeleton loading -->
     <video-skeleton v-if="!isPlioLoaded && !previewMode"></video-skeleton>
-    <div v-if="isPlioLoaded" class="flex relative shadow-lg" :class="containerClass">
+    <div
+      v-if="isPlioLoaded"
+      class="flex relative shadow-lg"
+      :class="containerClass"
+    >
       <!-- video player component -->
       <video-player
         :videoId="videoId"
@@ -84,25 +88,25 @@
 </template>
 
 <script>
-import VideoPlayer from '@/components/UI/Player/VideoPlayer'
-import VideoSkeleton from '@/components/UI/Skeletons/VideoSkeleton.vue'
-import Scorecard from '@/components/Items/Scorecard.vue'
-import PlioAPIService from '@/services/API/Plio.js'
-import UserAPIService from '@/services/API/User.js'
-import SessionAPIService from '@/services/API/Session.js'
-import EventAPIService from '@/services/API/Event.js'
-import VideoFunctionalService from '@/services/Functional/Video.js'
-import ItemFunctionalService from '@/services/Functional/Item.js'
-import ItemModal from '@/components/Player/ItemModal.vue'
-import IconButton from '@/components/UI/Buttons/IconButton.vue'
-import { useToast } from 'vue-toastification'
-import { mapActions, mapState, mapGetters } from 'vuex'
-import { resetConfetti } from '@/services/Functional/Utilities/Generic.js'
-import SettingsUtilities from '@/services/Functional/Utilities/Settings.js'
-import globalDefaultSettings from '@/services/Config/GlobalDefaultSettings.js'
+import VideoPlayer from "@/components/UI/Player/VideoPlayer"
+import VideoSkeleton from "@/components/UI/Skeletons/VideoSkeleton.vue"
+import Scorecard from "@/components/Items/Scorecard.vue"
+import PlioAPIService from "@/services/API/Plio.js"
+import UserAPIService from "@/services/API/User.js"
+import SessionAPIService from "@/services/API/Session.js"
+import EventAPIService from "@/services/API/Event.js"
+import VideoFunctionalService from "@/services/Functional/Video.js"
+import ItemFunctionalService from "@/services/Functional/Item.js"
+import ItemModal from "@/components/Player/ItemModal.vue"
+import IconButton from "@/components/UI/Buttons/IconButton.vue"
+import { useToast } from "vue-toastification"
+import { mapActions, mapState, mapGetters } from "vuex"
+import { resetConfetti } from "@/services/Functional/Utilities/Generic.js"
+import SettingsUtilities from "@/services/Functional/Utilities/Settings.js"
+import globalDefaultSettings from "@/services/Config/GlobalDefaultSettings.js"
 
-var isEqual = require('deep-eql')
-let clonedeep = require('lodash.clonedeep')
+var isEqual = require("deep-eql")
+let clonedeep = require("lodash.clonedeep")
 
 // difference in seconds between consecutive checks for item pop-up
 var POP_UP_CHECKING_FREQUENCY = 0.5
@@ -131,14 +135,14 @@ export default {
     return {
       plyrConfig: {
         controls: [
-          'play',
-          'play-large',
-          'progress',
-          'current-time',
-          'mute',
-          'volume',
-          'fullscreen',
-          'settings'
+          "play",
+          "play-large",
+          "progress",
+          "current-time",
+          "mute",
+          "volume",
+          "fullscreen",
+          "settings"
         ],
 
         keyboard: {
@@ -151,7 +155,7 @@ export default {
 
         invertTime: false
       },
-      videoId: '', // video Id for the Plio
+      videoId: "", // video Id for the Plio
       componentProperties: {}, // properties of the plio player
       items: [], // holds the list of all items for this plio
       itemDetails: [], // list of all the items' details created for this plio
@@ -161,29 +165,29 @@ export default {
       currentItemIndex: null, // current item being displayed
       markerClass: [
         // class for the item marker displayed on top of the video slider
-        'bg-red-600',
-        'absolute',
-        'z-10',
-        'transform',
-        'translate',
-        '-translate-x-2/4',
-        'translate-y-4',
-        'py-1.5',
-        'px-1',
-        'bottom-full',
-        'pointer-events-none',
-        'rounded-md'
+        "bg-red-600",
+        "absolute",
+        "z-10",
+        "transform",
+        "translate",
+        "-translate-x-2/4",
+        "translate-y-4",
+        "py-1.5",
+        "px-1",
+        "bottom-full",
+        "pointer-events-none",
+        "rounded-md"
       ],
       scorecardMarkerClass: [
-        'absolute',
-        'z-10',
-        'transform',
-        'translate',
-        '-translate-x-2/4',
-        'translate-y-6',
-        'bottom-full',
-        'pointer-events-none',
-        'text-2xl'
+        "absolute",
+        "z-10",
+        "transform",
+        "translate",
+        "-translate-x-2/4",
+        "translate-y-6",
+        "bottom-full",
+        "pointer-events-none",
+        "text-2xl"
       ],
       lastCheckTimestamp: 0, // time in milliseconds when the last check for item pop-up took place
       isFullscreen: false, // is the player in fullscreen
@@ -196,12 +200,12 @@ export default {
       isModalMinimized: false, // whether the item modal is minimized or not
       // styling class for the maximise button
       maximizeButtonClass:
-        'px-3 sm:p-2 sm:px-6 lg:p-4 lg:px-8 bg-primary hover:bg-primary-hover p-1 rounded-md shadow-xl disabled:opacity-50 disabled:pointer-events-none',
+        "px-3 sm:p-2 sm:px-6 lg:p-4 lg:px-8 bg-primary hover:bg-primary-hover p-1 rounded-md shadow-xl disabled:opacity-50 disabled:pointer-events-none",
       numCorrect: 0, // number of correctly answered questions
       numWrong: 0, // number of wrongly answered questions
       numSkipped: 0, // number of skipped questions
       isScorecardShown: false, // to show the scorecard or not
-      plioTitle: '', // title of the plio
+      plioTitle: "", // title of the plio
       isAspectRatioChecked: false, // whether the check for aspect ratio has been done
       watchingEventDBId: null, // the DB id of the latest 'watching' event for a given session
       plioSettings: null, // stores this plio's settings
@@ -229,11 +233,11 @@ export default {
     },
     isPlioLoaded(value) {
       // emit if a plio has completed loading
-      if (value) this.$emit('loaded')
+      if (value) this.$emit("loaded")
     },
     showItemModal(value) {
       // emit if an item's visibility has been toggled
-      this.$emit('item-toggle', value)
+      this.$emit("item-toggle", value)
     },
     itemResponses: {
       handler(value) {
@@ -279,14 +283,14 @@ export default {
           // object, then redirect the user to a 404 page
           if (error.response != undefined && error.response.status === 400) {
             this.$router.replace({
-              name: 'Player',
+              name: "Player",
               params: {
                 workspace: this.workspace,
                 plioId: this.plioId
               }
             })
             thirdPartyAuthPromiseResolve()
-          } else this.$router.replace({ name: '404' })
+          } else this.$router.replace({ name: "404" })
         })
     } else thirdPartyAuthPromiseResolve()
 
@@ -297,7 +301,7 @@ export default {
     this.fetchPlioCreateSession()
 
     // add listener for screen size being changed
-    window.addEventListener('resize', this.setScreenProperties)
+    window.addEventListener("resize", this.setScreenProperties)
   },
   beforeUnmount() {
     // remove timeout
@@ -305,15 +309,15 @@ export default {
   },
   unmounted() {
     // remove listeners
-    window.removeEventListener('resize', this.setScreenProperties)
+    window.removeEventListener("resize", this.setScreenProperties)
   },
   props: {
     plioId: {
-      default: '',
+      default: "",
       type: String
     },
     workspace: {
-      default: '',
+      default: "",
       type: String
     },
     thirdPartyUniqueId: {
@@ -336,15 +340,16 @@ export default {
      * custom classes for the plio container
      */
     containerClass: {
-      default: 'h-screen',
+      default: "h-screen",
       type: String
     }
   },
   computed: {
-    ...mapGetters('auth', ['isAuthenticated']),
-    ...mapState('generic', ['windowInnerWidth', 'windowInnerHeight']),
+    ...mapGetters("auth", ["isAuthenticated"]),
+    ...mapState("generic", ["windowInnerWidth", "windowInnerHeight"]),
     firstUnansweredItem() {
-      if (this.skipEnabled || this.lastAnsweredItemIndex == this.numItems - 1) return null
+      if (this.skipEnabled || this.lastAnsweredItemIndex == this.numItems - 1)
+        return null
       return this.items[this.lastAnsweredItemIndex + 1]
     },
     currentItem() {
@@ -357,15 +362,17 @@ export default {
     isSkipEnabled() {
       // if a custom configuration is provided, then use that otherwise
       // use the global settings
-      if (this.configuration != null && this.configuration.has('skipEnabled'))
-        return this.configuration.get('skipEnabled').value
-      return this.defaultConfiguration.get('skipEnabled').value
+      if (this.configuration != null && this.configuration.has("skipEnabled"))
+        return this.configuration.get("skipEnabled").value
+      return this.defaultConfiguration.get("skipEnabled").value
     },
     defaultConfiguration() {
-      return globalDefaultSettings.get('player').children.get('configuration').children
+      return globalDefaultSettings.get("player").children.get("configuration")
+        .children
     },
     configuration() {
-      return this.plioSettings.get('player').children.get('configuration').children
+      return this.plioSettings.get("player").children.get("configuration")
+        .children
     },
     /**
      * whether player has the correct aspect ratio as desired
@@ -374,7 +381,7 @@ export default {
       return (
         document
           .getElementById(this.plioContainerId)
-          .getElementsByClassName('plyr__video-embed')[0].style.paddingBottom ==
+          .getElementsByClassName("plyr__video-embed")[0].style.paddingBottom ==
         `${this.getDesiredPlayerAspectRatio}%`
       )
     },
@@ -422,26 +429,26 @@ export default {
     scorecardMetrics() {
       return [
         {
-          name: this.$t('player.scorecard.metric.description.correct'),
+          name: this.$t("player.scorecard.metric.description.correct"),
           icon: {
-            source: 'check.svg',
-            class: 'text-green-500'
+            source: "check.svg",
+            class: "text-green-500"
           },
           value: this.numCorrect
         },
         {
-          name: this.$t('player.scorecard.metric.description.wrong'),
+          name: this.$t("player.scorecard.metric.description.wrong"),
           icon: {
-            source: 'times-solid.svg',
-            class: 'text-red-500'
+            source: "times-solid.svg",
+            class: "text-red-500"
           },
           value: this.numWrong
         },
         {
-          name: this.$t('player.scorecard.metric.description.skipped'),
+          name: this.$t("player.scorecard.metric.description.skipped"),
           icon: {
-            source: 'skip.svg',
-            class: 'text-yellow-700'
+            source: "skip.svg",
+            class: "text-yellow-700"
           },
           value: this.numSkipped
         }
@@ -473,15 +480,15 @@ export default {
       return {
         value: this.isModalMinimized
           ? this.$t(`editor.buttons.show_${this.currentItemType}`)
-          : this.$t('editor.buttons.show_video'),
-        class: 'text-white text-md sm:text-base lg:text-xl font-bold'
+          : this.$t("editor.buttons.show_video"),
+        class: "text-white text-md sm:text-base lg:text-xl font-bold"
       }
     },
     /**
      * whether the plio has been loaded
      */
     isPlioLoaded() {
-      return this.videoId != ''
+      return this.videoId != ""
     },
     /**
      * whether there are any items
@@ -524,8 +531,8 @@ export default {
      */
     fullscreenButtonTitleConfig() {
       return {
-        value: this.$t('player.fullscreen.enter'),
-        class: 'text-white text-lg font-bold'
+        value: this.$t("player.fullscreen.enter"),
+        class: "text-white text-lg font-bold"
       }
     },
     /**
@@ -536,11 +543,12 @@ export default {
     }
   },
   methods: {
-    ...mapActions('auth', ['setAccessToken', 'setActiveWorkspace']),
+    ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
     isItemResponseEmpty(itemIndex, answer) {
       if (answer == null) return true
-      if (this.itemDetails[itemIndex].type == 'mcq') return isNaN(answer)
-      if (this.itemDetails[itemIndex].type == 'checkbox') return answer.length == 0
+      if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer)
+      if (this.itemDetails[itemIndex].type == "checkbox")
+        return answer.length == 0
       return false
     },
     /**
@@ -555,12 +563,13 @@ export default {
      */
     setPlayerVolumeVisibility() {
       let plyrInstance = document.getElementById(this.plioContainerId)
-      let plyrVolumeElement = plyrInstance.getElementsByClassName('plyr__volume')[0]
+      let plyrVolumeElement =
+        plyrInstance.getElementsByClassName("plyr__volume")[0]
       if (plyrVolumeElement == undefined) return
       if (plyrInstance.clientWidth < PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD) {
-        plyrVolumeElement.style.display = 'none'
+        plyrVolumeElement.style.display = "none"
       } else {
-        plyrVolumeElement.style.display = 'flex'
+        plyrVolumeElement.style.display = "flex"
       }
     },
     /**
@@ -575,7 +584,7 @@ export default {
        */
       const plyrElement = document
         .getElementById(this.plioContainerId) // to ensure that only this plio instance is affected and not other plyr instances
-        .getElementsByClassName('plyr__video-embed')[0]
+        .getElementsByClassName("plyr__video-embed")[0]
       if (plyrElement != undefined)
         plyrElement.style.paddingBottom = `${this.getDesiredPlayerAspectRatio}%`
     },
@@ -596,8 +605,9 @@ export default {
       if (this.isMovingToTimestampAllowed(this.player.duration) != null) return
       if (!this.isScorecardShown) {
         this.isScorecardShown = true
-        var scorecardModal = document.getElementById('scorecardmodal')
-        if (scorecardModal != undefined) this.mountOnFullscreenPlyr(scorecardModal)
+        var scorecardModal = document.getElementById("scorecardmodal")
+        if (scorecardModal != undefined)
+          this.mountOnFullscreenPlyr(scorecardModal)
       }
     },
     /**
@@ -610,7 +620,7 @@ export default {
       return (
         this.isItemSubjectiveQuestion(itemIndex) &&
         userAnswer != null &&
-        userAnswer.trim() != ''
+        userAnswer.trim() != ""
       )
     },
     /**
@@ -621,7 +631,9 @@ export default {
     updateNumCorrectWrongSkipped(itemIndex, userAnswer) {
       if (this.isItemMCQ(itemIndex) && !isNaN(userAnswer)) {
         const correctAnswer = this.itemDetails[itemIndex].correct_answer
-        userAnswer == correctAnswer ? (this.numCorrect += 1) : (this.numWrong += 1)
+        userAnswer == correctAnswer
+          ? (this.numCorrect += 1)
+          : (this.numWrong += 1)
         // reduce numSkipped by 1 if numCorrect or numWrong increases
         this.numSkipped -= 1
       } else if (
@@ -632,7 +644,9 @@ export default {
         // for checkbox questions, check if the answers match exactly
         const correctAnswer = this.itemDetails[itemIndex].correct_answer
 
-        isEqual(userAnswer, correctAnswer) ? (this.numCorrect += 1) : (this.numWrong += 1)
+        isEqual(userAnswer, correctAnswer)
+          ? (this.numCorrect += 1)
+          : (this.numWrong += 1)
         this.numSkipped -= 1
       } else if (this.isSubjectiveQuestionAnswered(itemIndex, userAnswer)) {
         // for subjective questions, as long as the viewer has given any answer
@@ -666,7 +680,7 @@ export default {
     mountOnFullscreenPlyr(elementToMount) {
       var plyrInstance = document
         .getElementById(this.plioContainerId)
-        .getElementsByClassName('plyr')[0]
+        .getElementsByClassName("plyr")[0]
       plyrInstance.insertBefore(elementToMount, plyrInstance.firstChild)
     },
     maximizeModal() {
@@ -680,13 +694,14 @@ export default {
       // set some CSS variables which tells the animation where the modal should shrink to
       // and where the maximize button should pop up. These variables are defined in `Editor.vue`
       let root = document.documentElement
-      root.style.setProperty('--t-origin-x', positions.centerX + 'px')
-      root.style.setProperty('--t-origin-y', positions.centerY + 'px')
+      root.style.setProperty("--t-origin-x", positions.centerX + "px")
+      root.style.setProperty("--t-origin-y", positions.centerY + "px")
 
       // insert the button inside the plyr instance so that it shows up in fullscreen mode
       this.$nextTick(() => {
-        let maximizeButton = document.getElementById('plioMaximizeButton')
-        if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton)
+        let maximizeButton = document.getElementById("plioMaximizeButton")
+        if (maximizeButton != undefined)
+          this.mountOnFullscreenPlyr(maximizeButton)
       })
     },
     isMovingToTimestampAllowed(timestamp) {
@@ -713,24 +728,27 @@ export default {
       if (
         this.isAnyItemActive &&
         this.player.currentTime < this.currentItem.time &&
-        this.player.currentTime >= this.currentItem.time - POP_UP_CHECKING_FREQUENCY
+        this.player.currentTime >=
+          this.currentItem.time - POP_UP_CHECKING_FREQUENCY
       )
         timeToInspect += POP_UP_CHECKING_FREQUENCY
 
       if (this.isMovingToTimestampAllowed(timeToInspect)) return false
 
       // move to first unanswered item
-      this.setPlayerTime(this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY)
+      this.setPlayerTime(
+        this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY
+      )
       this.showItemPopUpErrorToast = true
       return true
     },
     videoSeeked() {
       // invoked when a seek operation ends
-      this.createEvent('video_seeked', { currentTime: this.player.currentTime })
+      this.createEvent("video_seeked", { currentTime: this.player.currentTime })
     },
     optionSelected(optionIndex) {
       // invoked when an option of a question is selected
-      this.createEvent('option_selected', {
+      this.createEvent("option_selected", {
         itemIndex: this.currentItemIndex,
         optionIndex: optionIndex
       })
@@ -742,9 +760,10 @@ export default {
       this.player.currentTime =
         this.currentItemIndex == 0
           ? 0
-          : this.itemTimestamps[this.currentItemIndex - 1] + POP_UP_PRECISION_TIME / 1000
+          : this.itemTimestamps[this.currentItemIndex - 1] +
+            POP_UP_PRECISION_TIME / 1000
       // create an event for the revise action
-      this.createEvent('question_revised', { itemIndex: this.currentItemIndex })
+      this.createEvent("question_revised", { itemIndex: this.currentItemIndex })
       this.closeItemModal()
     },
     /**
@@ -760,7 +779,7 @@ export default {
       if (this.isAuthenticated && !this.previewMode) {
         SessionAPIService.updateSessionAnswer(itemResponse)
         // create an event for the submit action
-        this.createEvent('question_answered', {
+        this.createEvent("question_answered", {
           itemIndex: this.currentItemIndex,
           answer: itemResponse.answer
         })
@@ -777,12 +796,12 @@ export default {
     skipQuestion() {
       // invoked when the user skips the question
       this.closeItemModal()
-      this.createEvent('question_skipped', { itemIndex: this.currentItemIndex })
+      this.createEvent("question_skipped", { itemIndex: this.currentItemIndex })
     },
     proceedQuestion() {
       // invoked when the user has answered the question and wishes to proceed
       this.closeItemModal()
-      this.createEvent('question_proceed', { itemIndex: this.currentItemIndex })
+      this.createEvent("question_proceed", { itemIndex: this.currentItemIndex })
     },
     /**
      * fetches plio details and creates a new session
@@ -794,8 +813,8 @@ export default {
            * redirect to 404 if the plio is not published
            * and the plio is not opened in preview mode
            */
-          if (plioDetails.status != 'published' && !this.previewMode)
-            this.$router.replace({ name: '404' })
+          if (plioDetails.status != "published" && !this.previewMode)
+            this.$router.replace({ name: "404" })
           this.items = plioDetails.items || []
           this.itemDetails = plioDetails.itemDetails || []
           // setting numSkipped to number of items. This value will keep reducing
@@ -804,7 +823,9 @@ export default {
           this.plioDBId = plioDetails.plioDBId
           this.videoId = this.getVideoIDfromURL(plioDetails.videoURL)
           this.plioTitle = plioDetails.plioTitle
-          this.plioSettings = SettingsUtilities.setPlioSettings(plioDetails.config)
+          this.plioSettings = SettingsUtilities.setPlioSettings(
+            plioDetails.config
+          )
         })
         .then(() => this.createSession())
         .then(() => this.logData())
@@ -824,11 +845,11 @@ export default {
         this.updateSession()
         // if a 'watching' event exists for the current session, update that event
         // else create a new event
-        if (this.watchingEventDBId == null) this.createEvent('watching')
-        else this.updateEvent('watching', this.watchingEventDBId)
+        if (this.watchingEventDBId == null) this.createEvent("watching")
+        else this.updateEvent("watching", this.watchingEventDBId)
 
         this.$mixpanel.people.increment(
-          'Total Watch Time',
+          "Total Watch Time",
           this.watchTimeIncrement.toFixed(2)
         )
         this.watchTimeIncrement = 0
@@ -838,7 +859,7 @@ export default {
     closeItemModal() {
       // invoked when the modal is to be closed
       this.currentItemIndex = null
-      this.toast.dismiss('cannotSkipItem')
+      this.toast.dismiss("cannotSkipItem")
       this.playPlayer()
     },
     playPlayer() {
@@ -883,7 +904,7 @@ export default {
         // if this is the first session for this plio-user combination
         // increment the number of plios watched by this user
         if (sessionDetails.is_first) {
-          this.$mixpanel.people.increment('Total Plios Viewed')
+          this.$mixpanel.people.increment("Total Plios Viewed")
         }
 
         // handle retention array
@@ -899,7 +920,7 @@ export default {
           // create another dictionary every time we want to upload
           let itemResponse = {}
           for (let key of Object.keys(sessionAnswer)) {
-            itemResponse[key.replace('_id', '')] = sessionAnswer[key]
+            itemResponse[key.replace("_id", "")] = sessionAnswer[key]
           }
           // for mcq items, convert answers to integer
           if (this.isItemMCQ(itemIndex)) {
@@ -946,16 +967,17 @@ export default {
     },
     retentionStrToArray(retentionStr) {
       // convert retention string to retention array
-      return retentionStr.split(',').map((value) => parseInt(value))
+      return retentionStr.split(",").map((value) => parseInt(value))
     },
     retentionArrayToStr(retentionArray) {
       // convert retention array to retention string
-      return retentionArray.join(',')
+      return retentionArray.join(",")
     },
     getVideoIDfromURL(videoURL) {
       // gets the video Id from the YouTube URL
-      let linkValidation = VideoFunctionalService.isYouTubeVideoLinkValid(videoURL)
-      return linkValidation['ID']
+      let linkValidation =
+        VideoFunctionalService.isYouTubeVideoLinkValid(videoURL)
+      return linkValidation["ID"]
     },
     playerPlayed() {
       if (this.moveToFirstUnansweredItemOrPass()) {
@@ -974,16 +996,16 @@ export default {
         this.pausePlayer()
         return
       }
-      this.createEvent('played')
+      this.createEvent("played")
     },
     playerPaused() {
       // invoked when the pause button of the player is clicked
-      this.createEvent('paused')
+      this.createEvent("paused")
     },
     playerInitiated() {
       // sets the aspect ratio while the player is getting ready
       this.setPlayerAspectRatio()
-      this.$emit('initiated')
+      this.$emit("initiated")
     },
     /**
      * sets the current time of the player to the given time
@@ -998,10 +1020,10 @@ export default {
       // only show the scorecard when items are present in the plio
       if (this.isScorecardEnabled) this.showScorecardMarkerOnSlider()
       this.setPlayerTime(this.currentTimestamp)
-      this.$mixpanel.track('Visit Player', {
-        'Plio UUID': this.plioId,
-        'Plio Video Length': this.player.duration || 0,
-        'Plio Num Items': this.numItems || 0
+      this.$mixpanel.track("Visit Player", {
+        "Plio UUID": this.plioId,
+        "Plio Video Length": this.player.duration || 0,
+        "Plio Num Items": this.numItems || 0
       })
       // sets various properties based on the screen size
       this.setScreenProperties()
@@ -1016,10 +1038,10 @@ export default {
      * @param {Number} positionPercent - By what % from the left should the marker be placed
      */
     placeMarkerOnSlider(marker, classList, positionPercent) {
-      let plyrProgressBar = document.querySelectorAll('.plyr__progress')[0]
+      let plyrProgressBar = document.querySelectorAll(".plyr__progress")[0]
       if (plyrProgressBar != undefined) {
         marker.classList.add(...classList)
-        marker.style.setProperty('left', `${positionPercent}%`)
+        marker.style.setProperty("left", `${positionPercent}%`)
         plyrProgressBar.appendChild(marker)
       }
     },
@@ -1028,7 +1050,7 @@ export default {
      * @param {Object} marker - The HTML element that needs to be removed from the progress bar
      */
     removeMarkerOnSlider(marker) {
-      var plyrProgressBar = document.querySelectorAll('.plyr__progress')[0]
+      var plyrProgressBar = document.querySelectorAll(".plyr__progress")[0]
       if (plyrProgressBar != undefined) {
         plyrProgressBar.removeChild(marker)
       }
@@ -1040,16 +1062,17 @@ export default {
     showItemMarkersOnSlider() {
       this.items.forEach((item, index) => {
         let existingMarker = document.getElementById(`plioModalMarker-${index}`)
-        if (existingMarker != undefined) this.removeMarkerOnSlider(existingMarker)
+        if (existingMarker != undefined)
+          this.removeMarkerOnSlider(existingMarker)
 
         // add marker to player seek bar
-        let newMarker = document.createElement('SPAN')
-        newMarker.setAttribute('id', `plioModalMarker-${index}`)
+        let newMarker = document.createElement("SPAN")
+        newMarker.setAttribute("id", `plioModalMarker-${index}`)
 
         // set marker style and position
         if (this.isItemResponseDone(index)) {
-          this.markerClass[0] = 'bg-green-600'
-        } else this.markerClass[0] = 'bg-red-600'
+          this.markerClass[0] = "bg-green-600"
+        } else this.markerClass[0] = "bg-red-600"
 
         let positionPercent = (100 * item.time) / this.player.duration
 
@@ -1061,11 +1084,11 @@ export default {
      */
     showScorecardMarkerOnSlider() {
       // add marker to player seek bar
-      let newMarker = document.createElement('p')
-      newMarker.setAttribute('id', `plioScorecardMarker`)
+      let newMarker = document.createElement("p")
+      newMarker.setAttribute("id", `plioScorecardMarker`)
 
       // what the marker should look like - trophy cup emoji
-      newMarker.innerText = '🏆'
+      newMarker.innerText = "🏆"
 
       // set marker position
 
@@ -1075,7 +1098,8 @@ export default {
       // whether the response to an item is complete
       if (this.itemResponses && this.itemResponses[itemIndex]) {
         if (this.itemResponses[itemIndex].answer == null) return false
-        if (this.isItemMCQ(itemIndex)) return !isNaN(this.itemResponses[itemIndex].answer)
+        if (this.isItemMCQ(itemIndex))
+          return !isNaN(this.itemResponses[itemIndex].answer)
         return true
       }
       return false
@@ -1084,14 +1108,18 @@ export default {
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemMCQ(itemIndex) {
-      return this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'mcq'
+      return (
+        this.isItemQuestion(itemIndex) &&
+        this.itemDetails[itemIndex].type == "mcq"
+      )
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemCheckboxQuestion(itemIndex) {
       return (
-        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'checkbox'
+        this.isItemQuestion(itemIndex) &&
+        this.itemDetails[itemIndex].type == "checkbox"
       )
     },
     /**
@@ -1099,14 +1127,15 @@ export default {
      */
     isItemSubjectiveQuestion(itemIndex) {
       return (
-        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'subjective'
+        this.isItemQuestion(itemIndex) &&
+        this.itemDetails[itemIndex].type == "subjective"
       )
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemQuestion(itemIndex) {
-      return this.items[itemIndex].type == 'question'
+      return this.items[itemIndex].type == "question"
     },
     /**
      * invoked when the current time in the video is updated
@@ -1130,7 +1159,10 @@ export default {
      * @param {Number} timestamp - The player's current timestamp in seconds
      */
     checkForPopups(timestamp) {
-      if (Math.abs(timestamp - this.lastCheckTimestamp) < POP_UP_CHECKING_FREQUENCY)
+      if (
+        Math.abs(timestamp - this.lastCheckTimestamp) <
+        POP_UP_CHECKING_FREQUENCY
+      )
         return
       this.lastCheckTimestamp = timestamp
       if (!this.isAspectRatioChecked) this.checkAndSetPlayerAspectRatio()
@@ -1142,14 +1174,14 @@ export default {
         // show an error toast indicating that the user
         // has to answer the current item before moving ahead
         if (this.showItemPopUpErrorToast) {
-          this.toast.error(`☝️ ${this.$t('toast.player.cannot_skip_item')}`, {
-            id: 'cannotSkipItem',
-            position: 'bottom-center'
+          this.toast.error(`☝️ ${this.$t("toast.player.cannot_skip_item")}`, {
+            id: "cannotSkipItem",
+            position: "bottom-center"
           })
           this.showItemPopUpErrorToast = false
         }
         this.markItemSelected()
-        this.createEvent('item_opened', { itemIndex: this.currentItemIndex })
+        this.createEvent("item_opened", { itemIndex: this.currentItemIndex })
       } else {
         this.closeItemModal()
       }
@@ -1174,18 +1206,19 @@ export default {
       let modal = document.getElementById(this.plioModalElementId)
       if (modal != undefined) this.mountOnFullscreenPlyr(modal)
 
-      let maximizeButton = document.getElementById('plioMaximizeButton')
-      if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton)
+      let maximizeButton = document.getElementById("plioMaximizeButton")
+      if (maximizeButton != undefined)
+        this.mountOnFullscreenPlyr(maximizeButton)
     },
     enterPlayerFullscreen() {
       // sets the player to fullscreen
       this.isFullscreen = true
-      this.createEvent('enter_fullscreen')
+      this.createEvent("enter_fullscreen")
     },
     exitPlayerFullscreen() {
       // unsets the player from fullscreen
       this.isFullscreen = false
-      this.createEvent('exit_fullscreen')
+      this.createEvent("exit_fullscreen")
       this.setPlayerAspectRatio()
     },
     /**
@@ -1199,14 +1232,16 @@ export default {
        * or the user is not authenticated or if the plio is opened
        * in preview mode
        */
-      if (!this.hasSessionStarted || !this.isAuthenticated || this.previewMode) return
+      if (!this.hasSessionStarted || !this.isAuthenticated || this.previewMode)
+        return
       let response = await EventAPIService.createEvent({
         type: eventType,
         details: eventDetails,
-        player_time: this.player.currentTime != null ? this.player.currentTime : 0,
+        player_time:
+          this.player.currentTime != null ? this.player.currentTime : 0,
         session: this.sessionDBId
       })
-      if (eventType == 'watching') this.watchingEventDBId = response.id
+      if (eventType == "watching") this.watchingEventDBId = response.id
     },
     /**
      * Updates an event
@@ -1218,7 +1253,8 @@ export default {
       EventAPIService.updateEvent(eventDBId, {
         type: eventType,
         details: eventDetails,
-        player_time: this.player.currentTime != null ? this.player.currentTime : 0,
+        player_time:
+          this.player.currentTime != null ? this.player.currentTime : 0,
         session: this.sessionDBId
       })
     },
@@ -1226,7 +1262,7 @@ export default {
       this.isFullscreen = true
     }
   },
-  emits: ['initiated', 'loaded', 'item-toggle']
+  emits: ["initiated", "loaded", "item-toggle"]
 }
 </script>
 

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -84,40 +84,40 @@
 </template>
 
 <script>
-import VideoPlayer from "@/components/UI/Player/VideoPlayer";
-import VideoSkeleton from "@/components/UI/Skeletons/VideoSkeleton.vue";
-import Scorecard from "@/components/Items/Scorecard.vue";
-import PlioAPIService from "@/services/API/Plio.js";
-import UserAPIService from "@/services/API/User.js";
-import SessionAPIService from "@/services/API/Session.js";
-import EventAPIService from "@/services/API/Event.js";
-import VideoFunctionalService from "@/services/Functional/Video.js";
-import ItemFunctionalService from "@/services/Functional/Item.js";
-import ItemModal from "@/components/Player/ItemModal.vue";
-import IconButton from "@/components/UI/Buttons/IconButton.vue";
-import { useToast } from "vue-toastification";
-import { mapActions, mapState, mapGetters } from "vuex";
-import { resetConfetti } from "@/services/Functional/Utilities/Generic.js";
-import SettingsUtilities from "@/services/Functional/Utilities/Settings.js";
-import globalDefaultSettings from "@/services/Config/GlobalDefaultSettings.js";
+import VideoPlayer from '@/components/UI/Player/VideoPlayer'
+import VideoSkeleton from '@/components/UI/Skeletons/VideoSkeleton.vue'
+import Scorecard from '@/components/Items/Scorecard.vue'
+import PlioAPIService from '@/services/API/Plio.js'
+import UserAPIService from '@/services/API/User.js'
+import SessionAPIService from '@/services/API/Session.js'
+import EventAPIService from '@/services/API/Event.js'
+import VideoFunctionalService from '@/services/Functional/Video.js'
+import ItemFunctionalService from '@/services/Functional/Item.js'
+import ItemModal from '@/components/Player/ItemModal.vue'
+import IconButton from '@/components/UI/Buttons/IconButton.vue'
+import { useToast } from 'vue-toastification'
+import { mapActions, mapState, mapGetters } from 'vuex'
+import { resetConfetti } from '@/services/Functional/Utilities/Generic.js'
+import SettingsUtilities from '@/services/Functional/Utilities/Settings.js'
+import globalDefaultSettings from '@/services/Config/GlobalDefaultSettings.js'
 
-var isEqual = require("deep-eql");
-let clonedeep = require("lodash.clonedeep");
+var isEqual = require('deep-eql')
+let clonedeep = require('lodash.clonedeep')
 
 // difference in seconds between consecutive checks for item pop-up
-var POP_UP_CHECKING_FREQUENCY = 0.5;
-var POP_UP_PRECISION_TIME = POP_UP_CHECKING_FREQUENCY * 1000;
+var POP_UP_CHECKING_FREQUENCY = 0.5
+var POP_UP_PRECISION_TIME = POP_UP_CHECKING_FREQUENCY * 1000
 
 // the time period in which Plyr timeupdate event repeats
 // in seconds
-const PLYR_INTERVAL_TIME = 0.05;
+const PLYR_INTERVAL_TIME = 0.05
 
 // upload data periodically - period in milliseconds
-const UPLOAD_INTERVAL = 20000;
-var UPLOAD_INTERVAL_TIMEOUT = null;
+const UPLOAD_INTERVAL = 20000
+var UPLOAD_INTERVAL_TIMEOUT = null
 
 // screen width below which the volume bar won't be shown in the player controls
-const PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD = 640;
+const PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD = 640
 
 export default {
   components: {
@@ -125,33 +125,33 @@ export default {
     VideoSkeleton,
     ItemModal,
     IconButton,
-    Scorecard,
+    Scorecard
   },
   data() {
     return {
       plyrConfig: {
         controls: [
-          "play",
-          "play-large",
-          "progress",
-          "current-time",
-          "mute",
-          "volume",
-          "fullscreen",
-          "settings",
+          'play',
+          'play-large',
+          'progress',
+          'current-time',
+          'mute',
+          'volume',
+          'fullscreen',
+          'settings'
         ],
 
         keyboard: {
           focused: false,
-          global: false,
+          global: false
         },
 
         hideControls: false,
         clickToPlay: false,
 
-        invertTime: false,
+        invertTime: false
       },
-      videoId: "", // video Id for the Plio
+      videoId: '', // video Id for the Plio
       componentProperties: {}, // properties of the plio player
       items: [], // holds the list of all items for this plio
       itemDetails: [], // list of all the items' details created for this plio
@@ -161,29 +161,29 @@ export default {
       currentItemIndex: null, // current item being displayed
       markerClass: [
         // class for the item marker displayed on top of the video slider
-        "bg-red-600",
-        "absolute",
-        "z-10",
-        "transform",
-        "translate",
-        "-translate-x-2/4",
-        "translate-y-4",
-        "py-1.5",
-        "px-1",
-        "bottom-full",
-        "pointer-events-none",
-        "rounded-md",
+        'bg-red-600',
+        'absolute',
+        'z-10',
+        'transform',
+        'translate',
+        '-translate-x-2/4',
+        'translate-y-4',
+        'py-1.5',
+        'px-1',
+        'bottom-full',
+        'pointer-events-none',
+        'rounded-md'
       ],
       scorecardMarkerClass: [
-        "absolute",
-        "z-10",
-        "transform",
-        "translate",
-        "-translate-x-2/4",
-        "translate-y-6",
-        "bottom-full",
-        "pointer-events-none",
-        "text-2xl",
+        'absolute',
+        'z-10',
+        'transform',
+        'translate',
+        '-translate-x-2/4',
+        'translate-y-6',
+        'bottom-full',
+        'pointer-events-none',
+        'text-2xl'
       ],
       lastCheckTimestamp: 0, // time in milliseconds when the last check for item pop-up took place
       isFullscreen: false, // is the player in fullscreen
@@ -196,17 +196,17 @@ export default {
       isModalMinimized: false, // whether the item modal is minimized or not
       // styling class for the maximise button
       maximizeButtonClass:
-        "px-3 sm:p-2 sm:px-6 lg:p-4 lg:px-8 bg-primary hover:bg-primary-hover p-1 rounded-md shadow-xl disabled:opacity-50 disabled:pointer-events-none",
+        'px-3 sm:p-2 sm:px-6 lg:p-4 lg:px-8 bg-primary hover:bg-primary-hover p-1 rounded-md shadow-xl disabled:opacity-50 disabled:pointer-events-none',
       numCorrect: 0, // number of correctly answered questions
       numWrong: 0, // number of wrongly answered questions
       numSkipped: 0, // number of skipped questions
       isScorecardShown: false, // to show the scorecard or not
-      plioTitle: "", // title of the plio
+      plioTitle: '', // title of the plio
       isAspectRatioChecked: false, // whether the check for aspect ratio has been done
       watchingEventDBId: null, // the DB id of the latest 'watching' event for a given session
       plioSettings: null, // stores this plio's settings
-      lastAnsweredInteractionIndex: -1, // index of the interaction that was last answered
-    };
+      lastAnsweredItemIndex: -1 // index of the interaction that was last answered
+    }
   },
   watch: {
     isFullscreen(newIsFullscreen) {
@@ -216,34 +216,34 @@ export default {
         // trigger player fullscreen enter only if it is not already entered full screen
         // by other modes like player controls or double click on the video.
         if (!this.player.fullscreen.active) {
-          this.player.fullscreen.enter();
+          this.player.fullscreen.enter()
         }
       } else {
         // trigger player full screen exit only if it is not already exited full screen
         // by other modes like player controls or double click on the video.
         if (this.player.fullscreen.active) {
-          this.player.fullscreen.exit();
+          this.player.fullscreen.exit()
         }
       }
     },
     isPlioLoaded(value) {
       // emit if a plio has completed loading
-      if (value) this.$emit("loaded");
+      if (value) this.$emit('loaded')
     },
     showItemModal(value) {
       // emit if an item's visibility has been toggled
-      this.$emit("item-toggle", value);
+      this.$emit('item-toggle', value)
     },
     itemResponses: {
       handler(value) {
         // whenever itemResponses is updated, re-render the markers
         // and re-calculate the scorecard metrics
         if (value != undefined && this.player != undefined) {
-          this.showItemMarkersOnSlider();
+          this.showItemMarkersOnSlider()
         }
       },
-      deep: true,
-    },
+      deep: true
+    }
   },
   async created() {
     // Creating a promise for the third party auth functionality.
@@ -251,22 +251,22 @@ export default {
     // and the authenticated user is set.
     // If the app does not need third party auth, resolve the promise instantly.
     // All the remaining code will run only when this promise is resolved.
-    let thirdPartyAuthPromiseResolve;
+    let thirdPartyAuthPromiseResolve
     let thirdPartyAuthPromise = new Promise((resolve) => {
-      thirdPartyAuthPromiseResolve = resolve;
-    });
+      thirdPartyAuthPromiseResolve = resolve
+    })
 
     if (this.isThirdPartyAuth) {
       // convert the third party token into Plio's internal token
       // and set the user accordingly
       UserAPIService.generateExternalAuthToken({
         unique_id: this.thirdPartyUniqueId,
-        api_key: this.thirdPartyApiKey,
+        api_key: this.thirdPartyApiKey
       })
         .then(async (response) => {
-          await this.setAccessToken(response.data);
-          await this.setActiveWorkspace(this.workspace);
-          thirdPartyAuthPromiseResolve();
+          await this.setAccessToken(response.data)
+          await this.setActiveWorkspace(this.workspace)
+          thirdPartyAuthPromiseResolve()
         })
         .catch((error) => {
           // if there's some error in the query params,
@@ -278,50 +278,50 @@ export default {
           // object, then redirect the user to a 404 page
           if (error.response != undefined && error.response.status === 400) {
             this.$router.replace({
-              name: "Player",
+              name: 'Player',
               params: {
                 workspace: this.workspace,
-                plioId: this.plioId,
-              },
-            });
-            thirdPartyAuthPromiseResolve();
-          } else this.$router.replace({ name: "404" });
-        });
-    } else thirdPartyAuthPromiseResolve();
+                plioId: this.plioId
+              }
+            })
+            thirdPartyAuthPromiseResolve()
+          } else this.$router.replace({ name: '404' })
+        })
+    } else thirdPartyAuthPromiseResolve()
 
     // wait for the third party auth process to complete and then proceed
-    await thirdPartyAuthPromise;
+    await thirdPartyAuthPromise
 
     // load plio details
-    this.fetchPlioCreateSession();
+    this.fetchPlioCreateSession()
 
     // add listener for screen size being changed
-    window.addEventListener("resize", this.setScreenProperties);
+    window.addEventListener('resize', this.setScreenProperties)
   },
   beforeUnmount() {
     // remove timeout
-    clearTimeout(UPLOAD_INTERVAL_TIMEOUT);
+    clearTimeout(UPLOAD_INTERVAL_TIMEOUT)
   },
   unmounted() {
     // remove listeners
-    window.removeEventListener("resize", this.setScreenProperties);
+    window.removeEventListener('resize', this.setScreenProperties)
   },
   props: {
     plioId: {
-      default: "",
-      type: String,
+      default: '',
+      type: String
     },
     workspace: {
-      default: "",
-      type: String,
+      default: '',
+      type: String
     },
     thirdPartyUniqueId: {
       default: null,
-      type: String,
+      type: String
     },
     thirdPartyApiKey: {
       default: null,
-      type: String,
+      type: String
     },
     /**
      * whether it is being opened in preview mode
@@ -329,38 +329,38 @@ export default {
      */
     previewMode: {
       default: false,
-      type: Boolean,
+      type: Boolean
     },
     /**
      * custom classes for the plio container
      */
     containerClass: {
-      default: "h-screen",
-      type: String,
-    },
+      default: 'h-screen',
+      type: String
+    }
   },
   computed: {
-    ...mapGetters("auth", ["isAuthenticated"]),
-    ...mapState("generic", ["windowInnerWidth", "windowInnerHeight"]),
+    ...mapGetters('auth', ['isAuthenticated']),
+    ...mapState('generic', ['windowInnerWidth', 'windowInnerHeight']),
     currentItem() {
-      if (!this.isAnyItemActive) return null;
-      return this.items[this.currentItemIndex];
+      if (!this.isAnyItemActive) return null
+      return this.items[this.currentItemIndex]
     },
     numItems() {
-      return this.items.length;
+      return this.items.length
     },
     isSkipEnabled() {
       // if a custom configuration is provided, then use that otherwise
       // use the global settings
-      if (this.configuration != null && this.configuration.has("skipEnabled"))
-        return this.configuration.get("skipEnabled").value;
-      return this.defaultConfiguration.get("skipEnabled").value;
+      if (this.configuration != null && this.configuration.has('skipEnabled'))
+        return this.configuration.get('skipEnabled').value
+      return this.defaultConfiguration.get('skipEnabled').value
     },
     defaultConfiguration() {
-      return globalDefaultSettings.get("player").children.get("configuration").children;
+      return globalDefaultSettings.get('player').children.get('configuration').children
     },
     configuration() {
-      return this.plioSettings.get("player").children.get("configuration").children;
+      return this.plioSettings.get('player').children.get('configuration').children
     },
     /**
      * whether player has the correct aspect ratio as desired
@@ -369,47 +369,47 @@ export default {
       return (
         document
           .getElementById(this.plioContainerId)
-          .getElementsByClassName("plyr__video-embed")[0].style.paddingBottom ==
+          .getElementsByClassName('plyr__video-embed')[0].style.paddingBottom ==
         `${this.getDesiredPlayerAspectRatio}%`
-      );
+      )
     },
     /**
      * the desired aspect ratio for the player
      */
     getDesiredPlayerAspectRatio() {
-      return (100 * this.windowInnerHeight) / this.windowInnerWidth;
+      return (100 * this.windowInnerHeight) / this.windowInnerWidth
     },
     /**
      * id of the DOM element for the main container of the plio
      */
     plioContainerId() {
-      return `plio${this.plioId}`;
+      return `plio${this.plioId}`
     },
     /**
      * id of the DOM element for the video player
      */
     plioVideoPlayerElementId() {
-      return `plioVideoPlayer${this.plioId}`;
+      return `plioVideoPlayer${this.plioId}`
     },
     /**
      * id of the DOM element for the modal
      */
     plioModalElementId() {
-      return `plioModal${this.plioId}`;
+      return `plioModal${this.plioId}`
     },
     /**
      * whether the scorecard is enabled or not
      */
     isScorecardEnabled() {
-      return this.items != undefined && this.hasAnyItems;
+      return this.items != undefined && this.hasAnyItems
     },
     /**
      * progress value (0-100) to be passed to the Scorecard component
      */
     scorecardProgress() {
-      const totalAttempted = this.numCorrect + this.numWrong;
-      if (totalAttempted == 0) return null;
-      return (this.numCorrect / totalAttempted) * 100;
+      const totalAttempted = this.numCorrect + this.numWrong
+      if (totalAttempted == 0) return null
+      return (this.numCorrect / totalAttempted) * 100
     },
     /**
      * defines all the metrics to show in the scorecard here
@@ -417,49 +417,49 @@ export default {
     scorecardMetrics() {
       return [
         {
-          name: this.$t("player.scorecard.metric.description.correct"),
+          name: this.$t('player.scorecard.metric.description.correct'),
           icon: {
-            source: "check.svg",
-            class: "text-green-500",
+            source: 'check.svg',
+            class: 'text-green-500'
           },
-          value: this.numCorrect,
+          value: this.numCorrect
         },
         {
-          name: this.$t("player.scorecard.metric.description.wrong"),
+          name: this.$t('player.scorecard.metric.description.wrong'),
           icon: {
-            source: "times-solid.svg",
-            class: "text-red-500",
+            source: 'times-solid.svg',
+            class: 'text-red-500'
           },
-          value: this.numWrong,
+          value: this.numWrong
         },
         {
-          name: this.$t("player.scorecard.metric.description.skipped"),
+          name: this.$t('player.scorecard.metric.description.skipped'),
           icon: {
-            source: "skip.svg",
-            class: "text-yellow-700",
+            source: 'skip.svg',
+            class: 'text-yellow-700'
           },
-          value: this.numSkipped,
-        },
-      ];
+          value: this.numSkipped
+        }
+      ]
     },
     /**
      * number of questions that have been answered
      */
     numQuestionsAnswered() {
-      return this.numCorrect + this.numWrong;
+      return this.numCorrect + this.numWrong
     },
     /**
      * if the app needs to authenticate using a third party auth or not
      */
     isThirdPartyAuth() {
-      return this.thirdPartyUniqueId != null && this.thirdPartyApiKey != null;
+      return this.thirdPartyUniqueId != null && this.thirdPartyApiKey != null
     },
     /**
      * type of the current selected item
      * eg - question, note etc
      */
     currentItemType() {
-      return this.currentItem.type;
+      return this.currentItem.type
     },
     /**
      * config for the title of the maximise button
@@ -468,94 +468,94 @@ export default {
       return {
         value: this.isModalMinimized
           ? this.$t(`editor.buttons.show_${this.currentItemType}`)
-          : this.$t("editor.buttons.show_video"),
-        class: "text-white text-md sm:text-base lg:text-xl font-bold",
-      };
+          : this.$t('editor.buttons.show_video'),
+        class: 'text-white text-md sm:text-base lg:text-xl font-bold'
+      }
     },
     /**
      * whether the plio has been loaded
      */
     isPlioLoaded() {
-      return this.videoId != "";
+      return this.videoId != ''
     },
     /**
      * whether there are any items
      */
     hasAnyItems() {
-      return this.numItems != 0;
+      return this.numItems != 0
     },
     /**
      * whether any item is currently active
      */
     isAnyItemActive() {
-      return this.currentItemIndex != null;
+      return this.currentItemIndex != null
     },
     /**
      * whether the item modal needs to be shown
      */
     isItemModalShown() {
-      return this.hasAnyItems && this.isAnyItemActive;
+      return this.hasAnyItems && this.isAnyItemActive
     },
     /**
      * list of the timestamps for each of the items
      */
     itemTimestamps() {
-      return ItemFunctionalService.getItemTimestamps(this.items);
+      return ItemFunctionalService.getItemTimestamps(this.items)
     },
     /**
      * whether the session has been defined and begun
      */
     hasSessionStarted() {
-      return this.sessionDBId != null;
+      return this.sessionDBId != null
     },
     /**
      * returns the player instance
      */
     player() {
-      return this.$refs.videoPlayer.player;
+      return this.$refs.videoPlayer.player
     },
     /**
      * config for the text of the fullscreen toggle button
      */
     fullscreenButtonTitleConfig() {
       return {
-        value: this.$t("player.fullscreen.enter"),
-        class: "text-white text-lg font-bold",
-      };
+        value: this.$t('player.fullscreen.enter'),
+        class: 'text-white text-lg font-bold'
+      }
     },
     /**
      * class for the fullscreen button
      */
     fullscreenButtonClass() {
-      return `ring-2 ring-red-100 bg-primary hover:bg-primary-hover p-4 rounded-md shadow-xl place-self-center animate-bounce m-auto`;
-    },
+      return `ring-2 ring-red-100 bg-primary hover:bg-primary-hover p-4 rounded-md shadow-xl place-self-center animate-bounce m-auto`
+    }
   },
   methods: {
-    ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
+    ...mapActions('auth', ['setAccessToken', 'setActiveWorkspace']),
     isItemResponseEmpty(itemIndex, answer) {
-      if (answer == null) return true;
-      if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer);
-      if (this.itemDetails[itemIndex].type == "checkbox") return answer.length == 0;
-      return false;
+      if (answer == null) return true
+      if (this.itemDetails[itemIndex].type == 'mcq') return isNaN(answer)
+      if (this.itemDetails[itemIndex].type == 'checkbox') return answer.length == 0
+      return false
     },
     /**
      * sets various properties based on the screen size
      */
     setScreenProperties() {
-      this.setPlayerAspectRatio();
-      this.setPlayerVolumeVisibility();
+      this.setPlayerAspectRatio()
+      this.setPlayerVolumeVisibility()
     },
     /**
      * hides the volume control bar when the screen size is less than the threshold
      */
     setPlayerVolumeVisibility() {
-      let plyrInstance = document.getElementById(this.plioContainerId);
-      let plyrVolumeElement = plyrInstance.getElementsByClassName("plyr__volume")[0];
-      if (plyrVolumeElement == undefined) return;
+      let plyrInstance = document.getElementById(this.plioContainerId)
+      let plyrVolumeElement = plyrInstance.getElementsByClassName('plyr__volume')[0]
+      if (plyrVolumeElement == undefined) return
       if (plyrInstance.clientWidth < PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD) {
-        plyrVolumeElement.style.display = "none";
+        plyrVolumeElement.style.display = 'none'
       } else {
-        plyrVolumeElement.style.display = "flex";
+        plyrVolumeElement.style.display = 'flex'
       }
     },
     /**
@@ -570,9 +570,9 @@ export default {
        */
       const plyrElement = document
         .getElementById(this.plioContainerId) // to ensure that only this plio instance is affected and not other plyr instances
-        .getElementsByClassName("plyr__video-embed")[0];
+        .getElementsByClassName('plyr__video-embed')[0]
       if (plyrElement != undefined)
-        plyrElement.style.paddingBottom = `${this.getDesiredPlayerAspectRatio}%`;
+        plyrElement.style.paddingBottom = `${this.getDesiredPlayerAspectRatio}%`
     },
     /**
      * checks whether the correct aspect ratio has been set; if not,
@@ -580,19 +580,19 @@ export default {
      */
     checkAndSetPlayerAspectRatio() {
       if (!this.isAspectRatioChecked && !this.isAspectRatioCorrect) {
-        this.setPlayerAspectRatio();
-        this.isAspectRatioChecked = true;
+        this.setPlayerAspectRatio()
+        this.isAspectRatioChecked = true
       }
     },
     /**
      * Show the scorecard on top of the player
      */
     popupScorecard() {
-      if (this.checkMovingToTimestampAllowed(this.player.duration) != null) return;
+      if (this.checkMovingToTimestampAllowed(this.player.duration) != null) return
       if (!this.isScorecardShown) {
-        this.isScorecardShown = true;
-        var scorecardModal = document.getElementById("scorecardmodal");
-        if (scorecardModal != undefined) this.mountOnFullscreenPlyr(scorecardModal);
+        this.isScorecardShown = true
+        var scorecardModal = document.getElementById('scorecardmodal')
+        if (scorecardModal != undefined) this.mountOnFullscreenPlyr(scorecardModal)
       }
     },
     /**
@@ -605,8 +605,8 @@ export default {
       return (
         this.isItemSubjectiveQuestion(itemIndex) &&
         userAnswer != null &&
-        userAnswer.trim() != ""
-      );
+        userAnswer.trim() != ''
+      )
     },
     /**
      * Update the number of correct answers, wrong answers and skipped items
@@ -615,27 +615,25 @@ export default {
      */
     updateNumCorrectWrongSkipped(itemIndex, userAnswer) {
       if (this.isItemMCQ(itemIndex) && !isNaN(userAnswer)) {
-        const correctAnswer = this.itemDetails[itemIndex].correct_answer;
-        userAnswer == correctAnswer ? (this.numCorrect += 1) : (this.numWrong += 1);
+        const correctAnswer = this.itemDetails[itemIndex].correct_answer
+        userAnswer == correctAnswer ? (this.numCorrect += 1) : (this.numWrong += 1)
         // reduce numSkipped by 1 if numCorrect or numWrong increases
-        this.numSkipped -= 1;
+        this.numSkipped -= 1
       } else if (
         this.isItemCheckboxQuestion(itemIndex) &&
         userAnswer != null &&
         userAnswer.length > 0
       ) {
         // for checkbox questions, check if the answers match exactly
-        const correctAnswer = this.itemDetails[itemIndex].correct_answer;
+        const correctAnswer = this.itemDetails[itemIndex].correct_answer
 
-        isEqual(userAnswer, correctAnswer)
-          ? (this.numCorrect += 1)
-          : (this.numWrong += 1);
-        this.numSkipped -= 1;
+        isEqual(userAnswer, correctAnswer) ? (this.numCorrect += 1) : (this.numWrong += 1)
+        this.numSkipped -= 1
       } else if (this.isSubjectiveQuestionAnswered(itemIndex, userAnswer)) {
         // for subjective questions, as long as the viewer has given any answer
         // their response is considered correct
-        this.numCorrect += 1;
-        this.numSkipped -= 1;
+        this.numCorrect += 1
+        this.numSkipped -= 1
       }
     },
     /**
@@ -646,96 +644,104 @@ export default {
     calculateScorecardMetrics(itemIndex = null, userAnswer = null) {
       if (itemIndex == null) {
         this.itemResponses.forEach((itemResponse, itemIndex) => {
-          this.updateNumCorrectWrongSkipped(itemIndex, itemResponse.answer);
-        }, this);
+          this.updateNumCorrectWrongSkipped(itemIndex, itemResponse.answer)
+        }, this)
       } else {
-        this.updateNumCorrectWrongSkipped(itemIndex, userAnswer);
+        this.updateNumCorrectWrongSkipped(itemIndex, userAnswer)
       }
     },
     /**
      * remove the scorecard, restart the video and remove the confetti
      */
     restartVideo() {
-      this.isScorecardShown = false;
-      this.player.restart();
-      resetConfetti();
+      this.isScorecardShown = false
+      this.player.restart()
+      resetConfetti()
     },
     mountOnFullscreenPlyr(elementToMount) {
       var plyrInstance = document
         .getElementById(this.plioContainerId)
-        .getElementsByClassName("plyr")[0];
-      plyrInstance.insertBefore(elementToMount, plyrInstance.firstChild);
+        .getElementsByClassName('plyr')[0]
+      plyrInstance.insertBefore(elementToMount, plyrInstance.firstChild)
     },
     maximizeModal() {
       // toggle the minimized state of the modal
-      this.isModalMinimized = false;
+      this.isModalMinimized = false
     },
     minimizeModal(positions) {
       // invoked when minimize button is clicked
-      this.isModalMinimized = true;
+      this.isModalMinimized = true
 
       // set some CSS variables which tells the animation where the modal should shrink to
       // and where the maximize button should pop up. These variables are defined in `Editor.vue`
-      let root = document.documentElement;
-      root.style.setProperty("--t-origin-x", positions.centerX + "px");
-      root.style.setProperty("--t-origin-y", positions.centerY + "px");
+      let root = document.documentElement
+      root.style.setProperty('--t-origin-x', positions.centerX + 'px')
+      root.style.setProperty('--t-origin-y', positions.centerY + 'px')
 
       // insert the button inside the plyr instance so that it shows up in fullscreen mode
       this.$nextTick(() => {
-        let maximizeButton = document.getElementById("plioMaximizeButton");
-        if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton);
-      });
+        let maximizeButton = document.getElementById('plioMaximizeButton')
+        if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton)
+      })
     },
     checkMovingToTimestampAllowed(timestamp) {
-      if (!this.isSkipEnabled && this.lastAnsweredInteractionIndex < this.numItems - 1) {
-        const firstUnansweredInteraction = this.items[
-          this.lastAnsweredInteractionIndex + 1
-        ];
-        if (timestamp >= firstUnansweredInteraction.time)
-          return firstUnansweredInteraction;
+      // check whether skip is disabled and all items have been answered
+      if (!this.isSkipEnabled && this.lastAnsweredItemIndex < this.numItems - 1) {
+        const firstUnansweredItem = this.items[this.lastAnsweredItemIndex + 1]
+        if (timestamp >= firstUnansweredItem.time) return firstUnansweredItem
       }
     },
+    /**
+     * whether the user should be moved to the first unanswered item
+     * or allowed to pass through to whatever timestamp they are trying to
+     * go to
+     */
     moveToFirstUnansweredItemTimestampOrPass() {
-      if (this.isSkipEnabled) return false;
-      let timeToInspect = this.player.currentTime;
+      if (this.isSkipEnabled) return false
+      let timeToInspect = this.player.currentTime
 
+      /**
+       * this is required to handle the case that the user toggles
+       * the show video/question button while an item is active and tries
+       * to play the video since the user will be in the time range of item
+       * timestamp and item timestamp - POP_UP_CHECKING_FREQUENCY, the code
+       * after this snippet will function incorrectly
+       */
       if (
         this.isAnyItemActive &&
         this.player.currentTime < this.currentItem.time &&
         this.player.currentTime >= this.currentItem.time - POP_UP_CHECKING_FREQUENCY
       )
-        timeToInspect += POP_UP_CHECKING_FREQUENCY;
+        timeToInspect += POP_UP_CHECKING_FREQUENCY
 
-      const firstUnansweredInteraction = this.checkMovingToTimestampAllowed(
-        timeToInspect
-      );
-      if (firstUnansweredInteraction != null) {
-        this.setPlayerTime(firstUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY);
-        setTimeout(() => {
-          this.toast.error(this.$t("toast.player.cannot_skip_interaction"), {
-            id: "cannotSkipInteraction",
-            position: "bottom-center",
-          });
-        }, 500);
-        return true;
-      }
-      return false;
+      const firstUnansweredItem = this.checkMovingToTimestampAllowed(timeToInspect)
+      if (firstUnansweredItem == null) return false
+
+      // move to first unanswered item
+      this.setPlayerTime(firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY)
+      setTimeout(() => {
+        this.toast.error(`☝️ ${this.$t('toast.player.cannot_skip_item')}`, {
+          id: 'cannotSkipItem',
+          position: 'bottom-center'
+        })
+      }, 500)
+      return true
     },
     videoSeeked() {
       if (this.moveToFirstUnansweredItemTimestampOrPass()) {
-        this.isModalMinimized = false;
-        return;
+        this.isModalMinimized = false
+        return
       }
 
       // invoked when a seek operation ends
-      this.createEvent("video_seeked", { currentTime: this.player.currentTime });
+      this.createEvent('video_seeked', { currentTime: this.player.currentTime })
     },
     optionSelected(optionIndex) {
       // invoked when an option of a question is selected
-      this.createEvent("option_selected", {
+      this.createEvent('option_selected', {
         itemIndex: this.currentItemIndex,
-        optionIndex: optionIndex,
-      });
+        optionIndex: optionIndex
+      })
     },
     reviseQuestion() {
       // after revise is clicked, take the user either to the beginning
@@ -744,47 +750,47 @@ export default {
       this.player.currentTime =
         this.currentItemIndex == 0
           ? 0
-          : this.itemTimestamps[this.currentItemIndex - 1] + POP_UP_PRECISION_TIME / 1000;
+          : this.itemTimestamps[this.currentItemIndex - 1] + POP_UP_PRECISION_TIME / 1000
       // create an event for the revise action
-      this.createEvent("question_revised", { itemIndex: this.currentItemIndex });
-      this.closeItemModal();
+      this.createEvent('question_revised', { itemIndex: this.currentItemIndex })
+      this.closeItemModal()
     },
     /**
      * saves the answer to the question at the current index
      */
     submitQuestion() {
-      let itemResponse = this.itemResponses[this.currentItemIndex];
+      let itemResponse = this.itemResponses[this.currentItemIndex]
 
       /**
        * update the session answer on server if the user is authenticated
        * and the plio is not opened in preview mode
        */
       if (this.isAuthenticated && !this.previewMode) {
-        SessionAPIService.updateSessionAnswer(itemResponse);
+        SessionAPIService.updateSessionAnswer(itemResponse)
         // create an event for the submit action
-        this.createEvent("question_answered", {
+        this.createEvent('question_answered', {
           itemIndex: this.currentItemIndex,
-          answer: itemResponse.answer,
-        });
+          answer: itemResponse.answer
+        })
       }
 
-      this.lastAnsweredInteractionIndex = clonedeep(this.currentItemIndex);
+      this.lastAnsweredItemIndex = clonedeep(this.currentItemIndex)
 
       // update the marker colors on the player
-      this.showItemMarkersOnSlider();
+      this.showItemMarkersOnSlider()
 
       // recalculate the scorecard metrics
-      this.calculateScorecardMetrics(this.currentItemIndex, itemResponse.answer);
+      this.calculateScorecardMetrics(this.currentItemIndex, itemResponse.answer)
     },
     skipQuestion() {
       // invoked when the user skips the question
-      this.closeItemModal();
-      this.createEvent("question_skipped", { itemIndex: this.currentItemIndex });
+      this.closeItemModal()
+      this.createEvent('question_skipped', { itemIndex: this.currentItemIndex })
     },
     proceedQuestion() {
       // invoked when the user has answered the question and wishes to proceed
-      this.closeItemModal();
-      this.createEvent("question_proceed", { itemIndex: this.currentItemIndex });
+      this.closeItemModal()
+      this.createEvent('question_proceed', { itemIndex: this.currentItemIndex })
     },
     /**
      * fetches plio details and creates a new session
@@ -796,20 +802,20 @@ export default {
            * redirect to 404 if the plio is not published
            * and the plio is not opened in preview mode
            */
-          if (plioDetails.status != "published" && !this.previewMode)
-            this.$router.replace({ name: "404" });
-          this.items = plioDetails.items || [];
-          this.itemDetails = plioDetails.itemDetails || [];
+          if (plioDetails.status != 'published' && !this.previewMode)
+            this.$router.replace({ name: '404' })
+          this.items = plioDetails.items || []
+          this.itemDetails = plioDetails.itemDetails || []
           // setting numSkipped to number of items. This value will keep reducing
           // as numCorrect and numWrong are calculated
-          this.numSkipped = this.numItems;
-          this.plioDBId = plioDetails.plioDBId;
-          this.videoId = this.getVideoIDfromURL(plioDetails.videoURL);
-          this.plioTitle = plioDetails.plioTitle;
-          this.plioSettings = SettingsUtilities.setPlioSettings(plioDetails.config);
+          this.numSkipped = this.numItems
+          this.plioDBId = plioDetails.plioDBId
+          this.videoId = this.getVideoIDfromURL(plioDetails.videoURL)
+          this.plioTitle = plioDetails.plioTitle
+          this.plioSettings = SettingsUtilities.setPlioSettings(plioDetails.config)
         })
         .then(() => this.createSession())
-        .then(() => this.logData());
+        .then(() => this.logData())
     },
     /**
      * periodically logs data to the server
@@ -819,37 +825,37 @@ export default {
        * do not log data if the user is not authenticated
        * or if the plio is opened in preview mode
        */
-      if (!this.isAuthenticated || this.previewMode) return;
+      if (!this.isAuthenticated || this.previewMode) return
 
       if (this.hasSessionStarted) {
         // update session data
-        this.updateSession();
+        this.updateSession()
         // if a 'watching' event exists for the current session, update that event
         // else create a new event
-        if (this.watchingEventDBId == null) this.createEvent("watching");
-        else this.updateEvent("watching", this.watchingEventDBId);
+        if (this.watchingEventDBId == null) this.createEvent('watching')
+        else this.updateEvent('watching', this.watchingEventDBId)
 
         this.$mixpanel.people.increment(
-          "Total Watch Time",
+          'Total Watch Time',
           this.watchTimeIncrement.toFixed(2)
-        );
-        this.watchTimeIncrement = 0;
+        )
+        this.watchTimeIncrement = 0
       }
-      UPLOAD_INTERVAL_TIMEOUT = setTimeout(this.logData, UPLOAD_INTERVAL);
+      UPLOAD_INTERVAL_TIMEOUT = setTimeout(this.logData, UPLOAD_INTERVAL)
     },
     closeItemModal() {
       // invoked when the modal is to be closed
-      this.currentItemIndex = null;
-      this.toast.dismiss("cannotSkipInteraction");
-      this.playPlayer();
+      this.currentItemIndex = null
+      this.toast.dismiss('cannotSkipItem')
+      this.playPlayer()
     },
     playPlayer() {
       // plays the video player
-      this.player.play();
+      this.player.play()
     },
     pausePlayer() {
       // pauses the video player
-      this.player.pause();
+      this.player.pause()
     },
     /**
      * creates new user-plio session
@@ -864,72 +870,71 @@ export default {
         this.items.forEach((_, itemIndex) => {
           if (this.isItemMCQ(itemIndex)) {
             this.itemResponses.push({
-              answer: NaN,
-            });
+              answer: NaN
+            })
           } else {
             this.itemResponses.push({
-              answer: null,
-            });
+              answer: null
+            })
           }
-        });
-        return;
+        })
+        return
       }
 
       SessionAPIService.createSession(this.plioDBId).then((sessionDetails) => {
-        this.sessionDBId = sessionDetails.id;
+        this.sessionDBId = sessionDetails.id
         // reset the user to where they left off if they are returning
         if (sessionDetails.last_event != null) {
-          this.currentTimestamp = sessionDetails.last_event.player_time;
+          this.currentTimestamp = sessionDetails.last_event.player_time
         }
 
         // if this is the first session for this plio-user combination
         // increment the number of plios watched by this user
         if (sessionDetails.is_first) {
-          this.$mixpanel.people.increment("Total Plios Viewed");
+          this.$mixpanel.people.increment('Total Plios Viewed')
         }
 
         // handle retention array
-        this.retention = this.retentionStrToArray(sessionDetails.retention);
+        this.retention = this.retentionStrToArray(sessionDetails.retention)
 
         // set watch time
-        this.watchTime = sessionDetails.watch_time;
+        this.watchTime = sessionDetails.watch_time
 
         // set item responses
         sessionDetails.session_answers.forEach((sessionAnswer, itemIndex) => {
           // removing the _id in keys like session_id, question_id
           // so that we can directly update the answers without having to
           // create another dictionary every time we want to upload
-          let itemResponse = {};
+          let itemResponse = {}
           for (let key of Object.keys(sessionAnswer)) {
-            itemResponse[key.replace("_id", "")] = sessionAnswer[key];
+            itemResponse[key.replace('_id', '')] = sessionAnswer[key]
           }
           // for mcq items, convert answers to integer
           if (this.isItemMCQ(itemIndex)) {
-            itemResponse.answer = parseInt(itemResponse.answer);
+            itemResponse.answer = parseInt(itemResponse.answer)
           }
           if (
             !this.isItemResponseEmpty(itemIndex, itemResponse.answer) &&
             !this.isSkipEnabled
           ) {
-            this.lastAnsweredInteractionIndex = itemIndex;
+            this.lastAnsweredItemIndex = itemIndex
           }
-          this.itemResponses.push(itemResponse);
-        });
+          this.itemResponses.push(itemResponse)
+        })
         if (!this.isSkipEnabled) {
-          const firstUnansweredInteraction = this.checkMovingToTimestampAllowed(
+          const firstUnansweredItem = this.checkMovingToTimestampAllowed(
             this.currentTimestamp
-          );
+          )
           // check if any item before the current timestamp is unanswered
           // if there is, then update the timestamp to just before the
           // unanswered item
-          if (firstUnansweredInteraction != null) {
-            this.currentTimestamp =
-              firstUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;
+          if (firstUnansweredItem != null) {
+            this.currentTimestamp = firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY
           }
         }
         // once itemResponses is full, calculate all the scorecard metrics
-        this.calculateScorecardMetrics();
-      });
+        this.calculateScorecardMetrics()
+      })
     },
     /**
      * updates the session data on the server
@@ -939,31 +944,31 @@ export default {
        * do not try updating the session if the user is not authenticated
        * or if the plio is opened in preview mode
        */
-      if (!this.isAuthenticated || this.previewMode) return;
+      if (!this.isAuthenticated || this.previewMode) return
 
       return SessionAPIService.updateSession(this.sessionDBId, {
         plio: this.plioDBId,
         watch_time: this.watchTime,
-        retention: this.retentionArrayToStr(this.retention),
-      }).catch((err) => console.log(err));
+        retention: this.retentionArrayToStr(this.retention)
+      }).catch((err) => console.log(err))
     },
     retentionStrToArray(retentionStr) {
       // convert retention string to retention array
-      return retentionStr.split(",").map((value) => parseInt(value));
+      return retentionStr.split(',').map((value) => parseInt(value))
     },
     retentionArrayToStr(retentionArray) {
       // convert retention array to retention string
-      return retentionArray.join(",");
+      return retentionArray.join(',')
     },
     getVideoIDfromURL(videoURL) {
       // gets the video Id from the YouTube URL
-      let linkValidation = VideoFunctionalService.isYouTubeVideoLinkValid(videoURL);
-      return linkValidation["ID"];
+      let linkValidation = VideoFunctionalService.isYouTubeVideoLinkValid(videoURL)
+      return linkValidation['ID']
     },
     playerPlayed() {
       if (this.moveToFirstUnansweredItemTimestampOrPass()) {
-        this.pausePlayer();
-        return;
+        this.pausePlayer()
+        return
       }
 
       // invoked when the play button of the player is clicked
@@ -972,40 +977,40 @@ export default {
          * prevents the video from playing while the
          * scorecard is being shown
          */
-        this.pausePlayer();
-        return;
+        this.pausePlayer()
+        return
       }
-      this.createEvent("played");
+      this.createEvent('played')
     },
     playerPaused() {
       // invoked when the pause button of the player is clicked
-      this.createEvent("paused");
+      this.createEvent('paused')
     },
     playerInitiated() {
       // sets the aspect ratio while the player is getting ready
-      this.setPlayerAspectRatio();
-      this.$emit("initiated");
+      this.setPlayerAspectRatio()
+      this.$emit('initiated')
     },
     /**
      * sets the current time of the player to the given time
      * @param {Number} timestamp
      */
     setPlayerTime(timestamp) {
-      this.player.currentTime = timestamp;
+      this.player.currentTime = timestamp
     },
     playerReady() {
       // invoked when the player is ready
-      this.showItemMarkersOnSlider();
+      this.showItemMarkersOnSlider()
       // only show the scorecard when items are present in the plio
-      if (this.isScorecardEnabled) this.showScorecardMarkerOnSlider();
-      this.setPlayerTime(this.currentTimestamp);
-      this.$mixpanel.track("Visit Player", {
-        "Plio UUID": this.plioId,
-        "Plio Video Length": this.player.duration || 0,
-        "Plio Num Items": this.numItems || 0,
-      });
+      if (this.isScorecardEnabled) this.showScorecardMarkerOnSlider()
+      this.setPlayerTime(this.currentTimestamp)
+      this.$mixpanel.track('Visit Player', {
+        'Plio UUID': this.plioId,
+        'Plio Video Length': this.player.duration || 0,
+        'Plio Num Items': this.numItems || 0
+      })
       // sets various properties based on the screen size
-      this.setScreenProperties();
+      this.setScreenProperties()
 
       // disabling autoplay because of bug - issue #157
       // this.playPlayer();
@@ -1017,11 +1022,11 @@ export default {
      * @param {Number} positionPercent - By what % from the left should the marker be placed
      */
     placeMarkerOnSlider(marker, classList, positionPercent) {
-      let plyrProgressBar = document.querySelectorAll(".plyr__progress")[0];
+      let plyrProgressBar = document.querySelectorAll('.plyr__progress')[0]
       if (plyrProgressBar != undefined) {
-        marker.classList.add(...classList);
-        marker.style.setProperty("left", `${positionPercent}%`);
-        plyrProgressBar.appendChild(marker);
+        marker.classList.add(...classList)
+        marker.style.setProperty('left', `${positionPercent}%`)
+        plyrProgressBar.appendChild(marker)
       }
     },
     /**
@@ -1029,9 +1034,9 @@ export default {
      * @param {Object} marker - The HTML element that needs to be removed from the progress bar
      */
     removeMarkerOnSlider(marker) {
-      var plyrProgressBar = document.querySelectorAll(".plyr__progress")[0];
+      var plyrProgressBar = document.querySelectorAll('.plyr__progress')[0]
       if (plyrProgressBar != undefined) {
-        plyrProgressBar.removeChild(marker);
+        plyrProgressBar.removeChild(marker)
       }
     },
     /**
@@ -1040,91 +1045,90 @@ export default {
      */
     showItemMarkersOnSlider() {
       this.items.forEach((item, index) => {
-        let existingMarker = document.getElementById(`plioModalMarker-${index}`);
-        if (existingMarker != undefined) this.removeMarkerOnSlider(existingMarker);
+        let existingMarker = document.getElementById(`plioModalMarker-${index}`)
+        if (existingMarker != undefined) this.removeMarkerOnSlider(existingMarker)
 
         // add marker to player seek bar
-        let newMarker = document.createElement("SPAN");
-        newMarker.setAttribute("id", `plioModalMarker-${index}`);
+        let newMarker = document.createElement('SPAN')
+        newMarker.setAttribute('id', `plioModalMarker-${index}`)
 
         // set marker style and position
         if (this.isItemResponseDone(index)) {
-          this.markerClass[0] = "bg-green-600";
-        } else this.markerClass[0] = "bg-red-600";
+          this.markerClass[0] = 'bg-green-600'
+        } else this.markerClass[0] = 'bg-red-600'
 
-        let positionPercent = (100 * item.time) / this.player.duration;
+        let positionPercent = (100 * item.time) / this.player.duration
 
-        this.placeMarkerOnSlider(newMarker, this.markerClass, positionPercent);
-      });
+        this.placeMarkerOnSlider(newMarker, this.markerClass, positionPercent)
+      })
     },
     /**
      * Place the marker emoji for scorecard on the plyr progress bar
      */
     showScorecardMarkerOnSlider() {
       // add marker to player seek bar
-      let newMarker = document.createElement("p");
-      newMarker.setAttribute("id", `plioScorecardMarker`);
+      let newMarker = document.createElement('p')
+      newMarker.setAttribute('id', `plioScorecardMarker`)
 
       // what the marker should look like - trophy cup emoji
-      newMarker.innerText = "🏆";
+      newMarker.innerText = '🏆'
 
       // set marker position
 
-      this.placeMarkerOnSlider(newMarker, this.scorecardMarkerClass, 100);
+      this.placeMarkerOnSlider(newMarker, this.scorecardMarkerClass, 100)
     },
     isItemResponseDone(itemIndex) {
       // whether the response to an item is complete
       if (this.itemResponses && this.itemResponses[itemIndex]) {
-        if (this.itemResponses[itemIndex].answer == null) return false;
-        if (this.isItemMCQ(itemIndex))
-          return !isNaN(this.itemResponses[itemIndex].answer);
-        return true;
+        if (this.itemResponses[itemIndex].answer == null) return false
+        if (this.isItemMCQ(itemIndex)) return !isNaN(this.itemResponses[itemIndex].answer)
+        return true
       }
-      return false;
+      return false
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemMCQ(itemIndex) {
-      return this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == "mcq";
+      return this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'mcq'
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemCheckboxQuestion(itemIndex) {
       return (
-        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == "checkbox"
-      );
+        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'checkbox'
+      )
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemSubjectiveQuestion(itemIndex) {
       return (
-        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == "subjective"
-      );
+        this.isItemQuestion(itemIndex) && this.itemDetails[itemIndex].type == 'subjective'
+      )
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemQuestion(itemIndex) {
-      return this.items[itemIndex].type == "question";
+      return this.items[itemIndex].type == 'question'
     },
     /**
      * invoked when the current time in the video is updated
      */
     videoTimestampUpdated(timestamp) {
       // check if popups should be shown at the given timestamp or not
-      this.checkForPopups(timestamp);
+      this.checkForPopups(timestamp)
 
       // update watch time
-      this.watchTime += PLYR_INTERVAL_TIME;
-      this.watchTimeIncrement += PLYR_INTERVAL_TIME;
+      this.watchTime += PLYR_INTERVAL_TIME
+      this.watchTimeIncrement += PLYR_INTERVAL_TIME
       // update retention if the array is defined
-      let currentTime = Math.trunc(this.player.currentTime);
+      let currentTime = Math.trunc(this.player.currentTime)
       if (currentTime != this.lastTimestampRetention && this.retention.length) {
-        this.retention[currentTime] += 1;
-        this.lastTimestampRetention = currentTime;
+        this.retention[currentTime] += 1
+        this.lastTimestampRetention = currentTime
       }
     },
     /**
@@ -1133,17 +1137,17 @@ export default {
      */
     checkForPopups(timestamp) {
       if (Math.abs(timestamp - this.lastCheckTimestamp) < POP_UP_CHECKING_FREQUENCY)
-        return;
-      this.lastCheckTimestamp = timestamp;
-      if (!this.isAspectRatioChecked) this.checkAndSetPlayerAspectRatio();
+        return
+      this.lastCheckTimestamp = timestamp
+      if (!this.isAspectRatioChecked) this.checkAndSetPlayerAspectRatio()
 
-      const itemIndex = this.checkForItemPopup(timestamp);
+      const itemIndex = this.checkForItemPopup(timestamp)
       if (itemIndex != null) {
-        this.currentItemIndex = itemIndex;
-        this.markItemSelected();
-        this.createEvent("item_opened", { itemIndex: this.currentItemIndex });
+        this.currentItemIndex = itemIndex
+        this.markItemSelected()
+        this.createEvent('item_opened', { itemIndex: this.currentItemIndex })
       } else {
-        this.closeItemModal();
+        this.closeItemModal()
       }
     },
     /**
@@ -1151,34 +1155,34 @@ export default {
      * @param {Number} timestamp - The player's current timestamp in seconds
      */
     checkForItemPopup(timestamp) {
-      this.isModalMinimized = false;
+      this.isModalMinimized = false
       return ItemFunctionalService.checkItemPopup(
         timestamp,
         this.itemTimestamps,
         POP_UP_PRECISION_TIME
-      );
+      )
     },
     markItemSelected() {
       // mark the item at the currentItemIndex as selected
-      this.pausePlayer();
+      this.pausePlayer()
 
       // if the video is in fullscreen mode, show the modal on top of it
-      let modal = document.getElementById(this.plioModalElementId);
-      if (modal != undefined) this.mountOnFullscreenPlyr(modal);
+      let modal = document.getElementById(this.plioModalElementId)
+      if (modal != undefined) this.mountOnFullscreenPlyr(modal)
 
-      let maximizeButton = document.getElementById("plioMaximizeButton");
-      if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton);
+      let maximizeButton = document.getElementById('plioMaximizeButton')
+      if (maximizeButton != undefined) this.mountOnFullscreenPlyr(maximizeButton)
     },
     enterPlayerFullscreen() {
       // sets the player to fullscreen
-      this.isFullscreen = true;
-      this.createEvent("enter_fullscreen");
+      this.isFullscreen = true
+      this.createEvent('enter_fullscreen')
     },
     exitPlayerFullscreen() {
       // unsets the player from fullscreen
-      this.isFullscreen = false;
-      this.createEvent("exit_fullscreen");
-      this.setPlayerAspectRatio();
+      this.isFullscreen = false
+      this.createEvent('exit_fullscreen')
+      this.setPlayerAspectRatio()
     },
     /**
      * creates a new event
@@ -1191,14 +1195,14 @@ export default {
        * or the user is not authenticated or if the plio is opened
        * in preview mode
        */
-      if (!this.hasSessionStarted || !this.isAuthenticated || this.previewMode) return;
+      if (!this.hasSessionStarted || !this.isAuthenticated || this.previewMode) return
       let response = await EventAPIService.createEvent({
         type: eventType,
         details: eventDetails,
         player_time: this.player.currentTime != null ? this.player.currentTime : 0,
-        session: this.sessionDBId,
-      });
-      if (eventType == "watching") this.watchingEventDBId = response.id;
+        session: this.sessionDBId
+      })
+      if (eventType == 'watching') this.watchingEventDBId = response.id
     },
     /**
      * Updates an event
@@ -1211,15 +1215,15 @@ export default {
         type: eventType,
         details: eventDetails,
         player_time: this.player.currentTime != null ? this.player.currentTime : 0,
-        session: this.sessionDBId,
-      });
+        session: this.sessionDBId
+      })
     },
     goFullscreen() {
-      this.isFullscreen = true;
-    },
+      this.isFullscreen = true
+    }
   },
-  emits: ["initiated", "loaded", "item-toggle"],
-};
+  emits: ['initiated', 'loaded', 'item-toggle']
+}
 </script>
 
 <style lang="scss">

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -88,40 +88,40 @@
 </template>
 
 <script>
-import VideoPlayer from "@/components/UI/Player/VideoPlayer"
-import VideoSkeleton from "@/components/UI/Skeletons/VideoSkeleton.vue"
-import Scorecard from "@/components/Items/Scorecard.vue"
-import PlioAPIService from "@/services/API/Plio.js"
-import UserAPIService from "@/services/API/User.js"
-import SessionAPIService from "@/services/API/Session.js"
-import EventAPIService from "@/services/API/Event.js"
-import VideoFunctionalService from "@/services/Functional/Video.js"
-import ItemFunctionalService from "@/services/Functional/Item.js"
-import ItemModal from "@/components/Player/ItemModal.vue"
-import IconButton from "@/components/UI/Buttons/IconButton.vue"
-import { useToast } from "vue-toastification"
-import { mapActions, mapState, mapGetters } from "vuex"
-import { resetConfetti } from "@/services/Functional/Utilities/Generic.js"
-import SettingsUtilities from "@/services/Functional/Utilities/Settings.js"
-import globalDefaultSettings from "@/services/Config/GlobalDefaultSettings.js"
+import VideoPlayer from "@/components/UI/Player/VideoPlayer";
+import VideoSkeleton from "@/components/UI/Skeletons/VideoSkeleton.vue";
+import Scorecard from "@/components/Items/Scorecard.vue";
+import PlioAPIService from "@/services/API/Plio.js";
+import UserAPIService from "@/services/API/User.js";
+import SessionAPIService from "@/services/API/Session.js";
+import EventAPIService from "@/services/API/Event.js";
+import VideoFunctionalService from "@/services/Functional/Video.js";
+import ItemFunctionalService from "@/services/Functional/Item.js";
+import ItemModal from "@/components/Player/ItemModal.vue";
+import IconButton from "@/components/UI/Buttons/IconButton.vue";
+import { useToast } from "vue-toastification";
+import { mapActions, mapState, mapGetters } from "vuex";
+import { resetConfetti } from "@/services/Functional/Utilities/Generic.js";
+import SettingsUtilities from "@/services/Functional/Utilities/Settings.js";
+import globalDefaultSettings from "@/services/Config/GlobalDefaultSettings.js";
 
-var isEqual = require("deep-eql")
-let clonedeep = require("lodash.clonedeep")
+var isEqual = require("deep-eql");
+let clonedeep = require("lodash.clonedeep");
 
 // difference in seconds between consecutive checks for item pop-up
-var POP_UP_CHECKING_FREQUENCY = 0.5
-var POP_UP_PRECISION_TIME = POP_UP_CHECKING_FREQUENCY * 1000
+var POP_UP_CHECKING_FREQUENCY = 0.5;
+var POP_UP_PRECISION_TIME = POP_UP_CHECKING_FREQUENCY * 1000;
 
 // the time period in which Plyr timeupdate event repeats
 // in seconds
-const PLYR_INTERVAL_TIME = 0.05
+const PLYR_INTERVAL_TIME = 0.05;
 
 // upload data periodically - period in milliseconds
-const UPLOAD_INTERVAL = 20000
-var UPLOAD_INTERVAL_TIMEOUT = null
+const UPLOAD_INTERVAL = 20000;
+var UPLOAD_INTERVAL_TIMEOUT = null;
 
 // screen width below which the volume bar won't be shown in the player controls
-const PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD = 640
+const PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD = 640;
 
 export default {
   components: {
@@ -211,7 +211,7 @@ export default {
       plioSettings: null, // stores this plio's settings
       lastAnsweredItemIndex: -1, // index of the interaction that was last answered
       showItemPopUpErrorToast: false // whether to show the error toast when an item is opened
-    }
+    };
   },
   watch: {
     isFullscreen(newIsFullscreen) {
@@ -221,30 +221,30 @@ export default {
         // trigger player fullscreen enter only if it is not already entered full screen
         // by other modes like player controls or double click on the video.
         if (!this.player.fullscreen.active) {
-          this.player.fullscreen.enter()
+          this.player.fullscreen.enter();
         }
       } else {
         // trigger player full screen exit only if it is not already exited full screen
         // by other modes like player controls or double click on the video.
         if (this.player.fullscreen.active) {
-          this.player.fullscreen.exit()
+          this.player.fullscreen.exit();
         }
       }
     },
     isPlioLoaded(value) {
       // emit if a plio has completed loading
-      if (value) this.$emit("loaded")
+      if (value) this.$emit("loaded");
     },
     showItemModal(value) {
       // emit if an item's visibility has been toggled
-      this.$emit("item-toggle", value)
+      this.$emit("item-toggle", value);
     },
     itemResponses: {
       handler(value) {
         // whenever itemResponses is updated, re-render the markers
         // and re-calculate the scorecard metrics
         if (value != undefined && this.player != undefined) {
-          this.showItemMarkersOnSlider()
+          this.showItemMarkersOnSlider();
         }
       },
       deep: true
@@ -256,10 +256,10 @@ export default {
     // and the authenticated user is set.
     // If the app does not need third party auth, resolve the promise instantly.
     // All the remaining code will run only when this promise is resolved.
-    let thirdPartyAuthPromiseResolve
+    let thirdPartyAuthPromiseResolve;
     let thirdPartyAuthPromise = new Promise((resolve) => {
-      thirdPartyAuthPromiseResolve = resolve
-    })
+      thirdPartyAuthPromiseResolve = resolve;
+    });
 
     if (this.isThirdPartyAuth) {
       // convert the third party token into Plio's internal token
@@ -269,9 +269,9 @@ export default {
         api_key: this.thirdPartyApiKey
       })
         .then(async (response) => {
-          await this.setAccessToken(response.data)
-          await this.setActiveWorkspace(this.workspace)
-          thirdPartyAuthPromiseResolve()
+          await this.setAccessToken(response.data);
+          await this.setActiveWorkspace(this.workspace);
+          thirdPartyAuthPromiseResolve();
         })
         .catch((error) => {
           // if there's some error in the query params,
@@ -288,28 +288,28 @@ export default {
                 workspace: this.workspace,
                 plioId: this.plioId
               }
-            })
-            thirdPartyAuthPromiseResolve()
-          } else this.$router.replace({ name: "404" })
-        })
-    } else thirdPartyAuthPromiseResolve()
+            });
+            thirdPartyAuthPromiseResolve();
+          } else this.$router.replace({ name: "404" });
+        });
+    } else thirdPartyAuthPromiseResolve();
 
     // wait for the third party auth process to complete and then proceed
-    await thirdPartyAuthPromise
+    await thirdPartyAuthPromise;
 
     // load plio details
-    this.fetchPlioCreateSession()
+    this.fetchPlioCreateSession();
 
     // add listener for screen size being changed
-    window.addEventListener("resize", this.setScreenProperties)
+    window.addEventListener("resize", this.setScreenProperties);
   },
   beforeUnmount() {
     // remove timeout
-    clearTimeout(UPLOAD_INTERVAL_TIMEOUT)
+    clearTimeout(UPLOAD_INTERVAL_TIMEOUT);
   },
   unmounted() {
     // remove listeners
-    window.removeEventListener("resize", this.setScreenProperties)
+    window.removeEventListener("resize", this.setScreenProperties);
   },
   props: {
     plioId: {
@@ -349,30 +349,30 @@ export default {
     ...mapState("generic", ["windowInnerWidth", "windowInnerHeight"]),
     firstUnansweredItem() {
       if (this.skipEnabled || this.lastAnsweredItemIndex == this.numItems - 1)
-        return null
-      return this.items[this.lastAnsweredItemIndex + 1]
+        return null;
+      return this.items[this.lastAnsweredItemIndex + 1];
     },
     currentItem() {
-      if (!this.isAnyItemActive) return null
-      return this.items[this.currentItemIndex]
+      if (!this.isAnyItemActive) return null;
+      return this.items[this.currentItemIndex];
     },
     numItems() {
-      return this.items.length
+      return this.items.length;
     },
     isSkipEnabled() {
       // if a custom configuration is provided, then use that otherwise
       // use the global settings
       if (this.configuration != null && this.configuration.has("skipEnabled"))
-        return this.configuration.get("skipEnabled").value
-      return this.defaultConfiguration.get("skipEnabled").value
+        return this.configuration.get("skipEnabled").value;
+      return this.defaultConfiguration.get("skipEnabled").value;
     },
     defaultConfiguration() {
       return globalDefaultSettings.get("player").children.get("configuration")
-        .children
+        .children;
     },
     configuration() {
       return this.plioSettings.get("player").children.get("configuration")
-        .children
+        .children;
     },
     /**
      * whether player has the correct aspect ratio as desired
@@ -383,45 +383,45 @@ export default {
           .getElementById(this.plioContainerId)
           .getElementsByClassName("plyr__video-embed")[0].style.paddingBottom ==
         `${this.getDesiredPlayerAspectRatio}%`
-      )
+      );
     },
     /**
      * the desired aspect ratio for the player
      */
     getDesiredPlayerAspectRatio() {
-      return (100 * this.windowInnerHeight) / this.windowInnerWidth
+      return (100 * this.windowInnerHeight) / this.windowInnerWidth;
     },
     /**
      * id of the DOM element for the main container of the plio
      */
     plioContainerId() {
-      return `plio${this.plioId}`
+      return `plio${this.plioId}`;
     },
     /**
      * id of the DOM element for the video player
      */
     plioVideoPlayerElementId() {
-      return `plioVideoPlayer${this.plioId}`
+      return `plioVideoPlayer${this.plioId}`;
     },
     /**
      * id of the DOM element for the modal
      */
     plioModalElementId() {
-      return `plioModal${this.plioId}`
+      return `plioModal${this.plioId}`;
     },
     /**
      * whether the scorecard is enabled or not
      */
     isScorecardEnabled() {
-      return this.items != undefined && this.hasAnyItems
+      return this.items != undefined && this.hasAnyItems;
     },
     /**
      * progress value (0-100) to be passed to the Scorecard component
      */
     scorecardProgress() {
-      const totalAttempted = this.numCorrect + this.numWrong
-      if (totalAttempted == 0) return null
-      return (this.numCorrect / totalAttempted) * 100
+      const totalAttempted = this.numCorrect + this.numWrong;
+      if (totalAttempted == 0) return null;
+      return (this.numCorrect / totalAttempted) * 100;
     },
     /**
      * defines all the metrics to show in the scorecard here
@@ -452,26 +452,26 @@ export default {
           },
           value: this.numSkipped
         }
-      ]
+      ];
     },
     /**
      * number of questions that have been answered
      */
     numQuestionsAnswered() {
-      return this.numCorrect + this.numWrong
+      return this.numCorrect + this.numWrong;
     },
     /**
      * if the app needs to authenticate using a third party auth or not
      */
     isThirdPartyAuth() {
-      return this.thirdPartyUniqueId != null && this.thirdPartyApiKey != null
+      return this.thirdPartyUniqueId != null && this.thirdPartyApiKey != null;
     },
     /**
      * type of the current selected item
      * eg - question, note etc
      */
     currentItemType() {
-      return this.currentItem.type
+      return this.currentItem.type;
     },
     /**
      * config for the title of the maximise button
@@ -482,49 +482,49 @@ export default {
           ? this.$t(`editor.buttons.show_${this.currentItemType}`)
           : this.$t("editor.buttons.show_video"),
         class: "text-white text-md sm:text-base lg:text-xl font-bold"
-      }
+      };
     },
     /**
      * whether the plio has been loaded
      */
     isPlioLoaded() {
-      return this.videoId != ""
+      return this.videoId != "";
     },
     /**
      * whether there are any items
      */
     hasAnyItems() {
-      return this.numItems != 0
+      return this.numItems != 0;
     },
     /**
      * whether any item is currently active
      */
     isAnyItemActive() {
-      return this.currentItemIndex != null
+      return this.currentItemIndex != null;
     },
     /**
      * whether the item modal needs to be shown
      */
     isItemModalShown() {
-      return this.hasAnyItems && this.isAnyItemActive
+      return this.hasAnyItems && this.isAnyItemActive;
     },
     /**
      * list of the timestamps for each of the items
      */
     itemTimestamps() {
-      return ItemFunctionalService.getItemTimestamps(this.items)
+      return ItemFunctionalService.getItemTimestamps(this.items);
     },
     /**
      * whether the session has been defined and begun
      */
     hasSessionStarted() {
-      return this.sessionDBId != null
+      return this.sessionDBId != null;
     },
     /**
      * returns the player instance
      */
     player() {
-      return this.$refs.videoPlayer.player
+      return this.$refs.videoPlayer.player;
     },
     /**
      * config for the text of the fullscreen toggle button
@@ -533,43 +533,43 @@ export default {
       return {
         value: this.$t("player.fullscreen.enter"),
         class: "text-white text-lg font-bold"
-      }
+      };
     },
     /**
      * class for the fullscreen button
      */
     fullscreenButtonClass() {
-      return `ring-2 ring-red-100 bg-primary hover:bg-primary-hover p-4 rounded-md shadow-xl place-self-center animate-bounce m-auto`
+      return `ring-2 ring-red-100 bg-primary hover:bg-primary-hover p-4 rounded-md shadow-xl place-self-center animate-bounce m-auto`;
     }
   },
   methods: {
     ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
     isItemResponseEmpty(itemIndex, answer) {
-      if (answer == null) return true
-      if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer)
+      if (answer == null) return true;
+      if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer);
       if (this.itemDetails[itemIndex].type == "checkbox")
-        return answer.length == 0
-      return false
+        return answer.length == 0;
+      return false;
     },
     /**
      * sets various properties based on the screen size
      */
     setScreenProperties() {
-      this.setPlayerAspectRatio()
-      this.setPlayerVolumeVisibility()
+      this.setPlayerAspectRatio();
+      this.setPlayerVolumeVisibility();
     },
     /**
      * hides the volume control bar when the screen size is less than the threshold
      */
     setPlayerVolumeVisibility() {
-      let plyrInstance = document.getElementById(this.plioContainerId)
+      let plyrInstance = document.getElementById(this.plioContainerId);
       let plyrVolumeElement =
-        plyrInstance.getElementsByClassName("plyr__volume")[0]
-      if (plyrVolumeElement == undefined) return
+        plyrInstance.getElementsByClassName("plyr__volume")[0];
+      if (plyrVolumeElement == undefined) return;
       if (plyrInstance.clientWidth < PLAYER_VOLUME_DISPLAY_WIDTH_THRESHOLD) {
-        plyrVolumeElement.style.display = "none"
+        plyrVolumeElement.style.display = "none";
       } else {
-        plyrVolumeElement.style.display = "flex"
+        plyrVolumeElement.style.display = "flex";
       }
     },
     /**
@@ -584,9 +584,9 @@ export default {
        */
       const plyrElement = document
         .getElementById(this.plioContainerId) // to ensure that only this plio instance is affected and not other plyr instances
-        .getElementsByClassName("plyr__video-embed")[0]
+        .getElementsByClassName("plyr__video-embed")[0];
       if (plyrElement != undefined)
-        plyrElement.style.paddingBottom = `${this.getDesiredPlayerAspectRatio}%`
+        plyrElement.style.paddingBottom = `${this.getDesiredPlayerAspectRatio}%`;
     },
     /**
      * checks whether the correct aspect ratio has been set; if not,
@@ -594,20 +594,20 @@ export default {
      */
     checkAndSetPlayerAspectRatio() {
       if (!this.isAspectRatioChecked && !this.isAspectRatioCorrect) {
-        this.setPlayerAspectRatio()
-        this.isAspectRatioChecked = true
+        this.setPlayerAspectRatio();
+        this.isAspectRatioChecked = true;
       }
     },
     /**
      * Show the scorecard on top of the player
      */
     popupScorecard() {
-      if (this.isMovingToTimestampAllowed(this.player.duration) != null) return
+      if (this.isMovingToTimestampAllowed(this.player.duration) != null) return;
       if (!this.isScorecardShown) {
-        this.isScorecardShown = true
-        var scorecardModal = document.getElementById("scorecardmodal")
+        this.isScorecardShown = true;
+        var scorecardModal = document.getElementById("scorecardmodal");
         if (scorecardModal != undefined)
-          this.mountOnFullscreenPlyr(scorecardModal)
+          this.mountOnFullscreenPlyr(scorecardModal);
       }
     },
     /**
@@ -621,7 +621,7 @@ export default {
         this.isItemSubjectiveQuestion(itemIndex) &&
         userAnswer != null &&
         userAnswer.trim() != ""
-      )
+      );
     },
     /**
      * Update the number of correct answers, wrong answers and skipped items
@@ -630,29 +630,29 @@ export default {
      */
     updateNumCorrectWrongSkipped(itemIndex, userAnswer) {
       if (this.isItemMCQ(itemIndex) && !isNaN(userAnswer)) {
-        const correctAnswer = this.itemDetails[itemIndex].correct_answer
+        const correctAnswer = this.itemDetails[itemIndex].correct_answer;
         userAnswer == correctAnswer
           ? (this.numCorrect += 1)
-          : (this.numWrong += 1)
+          : (this.numWrong += 1);
         // reduce numSkipped by 1 if numCorrect or numWrong increases
-        this.numSkipped -= 1
+        this.numSkipped -= 1;
       } else if (
         this.isItemCheckboxQuestion(itemIndex) &&
         userAnswer != null &&
         userAnswer.length > 0
       ) {
         // for checkbox questions, check if the answers match exactly
-        const correctAnswer = this.itemDetails[itemIndex].correct_answer
+        const correctAnswer = this.itemDetails[itemIndex].correct_answer;
 
         isEqual(userAnswer, correctAnswer)
           ? (this.numCorrect += 1)
-          : (this.numWrong += 1)
-        this.numSkipped -= 1
+          : (this.numWrong += 1);
+        this.numSkipped -= 1;
       } else if (this.isSubjectiveQuestionAnswered(itemIndex, userAnswer)) {
         // for subjective questions, as long as the viewer has given any answer
         // their response is considered correct
-        this.numCorrect += 1
-        this.numSkipped -= 1
+        this.numCorrect += 1;
+        this.numSkipped -= 1;
       }
     },
     /**
@@ -663,51 +663,51 @@ export default {
     calculateScorecardMetrics(itemIndex = null, userAnswer = null) {
       if (itemIndex == null) {
         this.itemResponses.forEach((itemResponse, itemIndex) => {
-          this.updateNumCorrectWrongSkipped(itemIndex, itemResponse.answer)
-        }, this)
+          this.updateNumCorrectWrongSkipped(itemIndex, itemResponse.answer);
+        }, this);
       } else {
-        this.updateNumCorrectWrongSkipped(itemIndex, userAnswer)
+        this.updateNumCorrectWrongSkipped(itemIndex, userAnswer);
       }
     },
     /**
      * remove the scorecard, restart the video and remove the confetti
      */
     restartVideo() {
-      this.isScorecardShown = false
-      this.player.restart()
-      resetConfetti()
+      this.isScorecardShown = false;
+      this.player.restart();
+      resetConfetti();
     },
     mountOnFullscreenPlyr(elementToMount) {
       var plyrInstance = document
         .getElementById(this.plioContainerId)
-        .getElementsByClassName("plyr")[0]
-      plyrInstance.insertBefore(elementToMount, plyrInstance.firstChild)
+        .getElementsByClassName("plyr")[0];
+      plyrInstance.insertBefore(elementToMount, plyrInstance.firstChild);
     },
     maximizeModal() {
       // toggle the minimized state of the modal
-      this.isModalMinimized = false
+      this.isModalMinimized = false;
     },
     minimizeModal(positions) {
       // invoked when minimize button is clicked
-      this.isModalMinimized = true
+      this.isModalMinimized = true;
 
       // set some CSS variables which tells the animation where the modal should shrink to
       // and where the maximize button should pop up. These variables are defined in `Editor.vue`
-      let root = document.documentElement
-      root.style.setProperty("--t-origin-x", positions.centerX + "px")
-      root.style.setProperty("--t-origin-y", positions.centerY + "px")
+      let root = document.documentElement;
+      root.style.setProperty("--t-origin-x", positions.centerX + "px");
+      root.style.setProperty("--t-origin-y", positions.centerY + "px");
 
       // insert the button inside the plyr instance so that it shows up in fullscreen mode
       this.$nextTick(() => {
-        let maximizeButton = document.getElementById("plioMaximizeButton")
+        let maximizeButton = document.getElementById("plioMaximizeButton");
         if (maximizeButton != undefined)
-          this.mountOnFullscreenPlyr(maximizeButton)
-      })
+          this.mountOnFullscreenPlyr(maximizeButton);
+      });
     },
     isMovingToTimestampAllowed(timestamp) {
-      if (this.firstUnansweredItem == null) return true
+      if (this.firstUnansweredItem == null) return true;
       // check whether skip is disabled and all items have been answered
-      return timestamp < this.firstUnansweredItem.time
+      return timestamp < this.firstUnansweredItem.time;
     },
     /**
      * whether the user should be moved to the first unanswered item
@@ -715,8 +715,8 @@ export default {
      * go to
      */
     moveToFirstUnansweredItemOrPass() {
-      if (this.isSkipEnabled) return false
-      let timeToInspect = this.player.currentTime
+      if (this.isSkipEnabled) return false;
+      let timeToInspect = this.player.currentTime;
 
       /**
        * this is required to handle the case that the user toggles
@@ -731,27 +731,29 @@ export default {
         this.player.currentTime >=
           this.currentItem.time - POP_UP_CHECKING_FREQUENCY
       )
-        timeToInspect += POP_UP_CHECKING_FREQUENCY
+        timeToInspect += POP_UP_CHECKING_FREQUENCY;
 
-      if (this.isMovingToTimestampAllowed(timeToInspect)) return false
+      if (this.isMovingToTimestampAllowed(timeToInspect)) return false;
 
       // move to first unanswered item
       this.setPlayerTime(
         this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY
-      )
-      this.showItemPopUpErrorToast = true
-      return true
+      );
+      this.showItemPopUpErrorToast = true;
+      return true;
     },
     videoSeeked() {
       // invoked when a seek operation ends
-      this.createEvent("video_seeked", { currentTime: this.player.currentTime })
+      this.createEvent("video_seeked", {
+        currentTime: this.player.currentTime
+      });
     },
     optionSelected(optionIndex) {
       // invoked when an option of a question is selected
       this.createEvent("option_selected", {
         itemIndex: this.currentItemIndex,
         optionIndex: optionIndex
-      })
+      });
     },
     reviseQuestion() {
       // after revise is clicked, take the user either to the beginning
@@ -761,47 +763,56 @@ export default {
         this.currentItemIndex == 0
           ? 0
           : this.itemTimestamps[this.currentItemIndex - 1] +
-            POP_UP_PRECISION_TIME / 1000
+            POP_UP_PRECISION_TIME / 1000;
       // create an event for the revise action
-      this.createEvent("question_revised", { itemIndex: this.currentItemIndex })
-      this.closeItemModal()
+      this.createEvent("question_revised", {
+        itemIndex: this.currentItemIndex
+      });
+      this.closeItemModal();
     },
     /**
      * saves the answer to the question at the current index
      */
     submitQuestion() {
-      let itemResponse = this.itemResponses[this.currentItemIndex]
+      let itemResponse = this.itemResponses[this.currentItemIndex];
 
       /**
        * update the session answer on server if the user is authenticated
        * and the plio is not opened in preview mode
        */
       if (this.isAuthenticated && !this.previewMode) {
-        SessionAPIService.updateSessionAnswer(itemResponse)
+        SessionAPIService.updateSessionAnswer(itemResponse);
         // create an event for the submit action
         this.createEvent("question_answered", {
           itemIndex: this.currentItemIndex,
           answer: itemResponse.answer
-        })
+        });
       }
 
-      this.lastAnsweredItemIndex = clonedeep(this.currentItemIndex)
+      this.lastAnsweredItemIndex = clonedeep(this.currentItemIndex);
 
       // update the marker colors on the player
-      this.showItemMarkersOnSlider()
+      this.showItemMarkersOnSlider();
 
       // recalculate the scorecard metrics
-      this.calculateScorecardMetrics(this.currentItemIndex, itemResponse.answer)
+      this.calculateScorecardMetrics(
+        this.currentItemIndex,
+        itemResponse.answer
+      );
     },
     skipQuestion() {
       // invoked when the user skips the question
-      this.closeItemModal()
-      this.createEvent("question_skipped", { itemIndex: this.currentItemIndex })
+      this.closeItemModal();
+      this.createEvent("question_skipped", {
+        itemIndex: this.currentItemIndex
+      });
     },
     proceedQuestion() {
       // invoked when the user has answered the question and wishes to proceed
-      this.closeItemModal()
-      this.createEvent("question_proceed", { itemIndex: this.currentItemIndex })
+      this.closeItemModal();
+      this.createEvent("question_proceed", {
+        itemIndex: this.currentItemIndex
+      });
     },
     /**
      * fetches plio details and creates a new session
@@ -814,21 +825,21 @@ export default {
            * and the plio is not opened in preview mode
            */
           if (plioDetails.status != "published" && !this.previewMode)
-            this.$router.replace({ name: "404" })
-          this.items = plioDetails.items || []
-          this.itemDetails = plioDetails.itemDetails || []
+            this.$router.replace({ name: "404" });
+          this.items = plioDetails.items || [];
+          this.itemDetails = plioDetails.itemDetails || [];
           // setting numSkipped to number of items. This value will keep reducing
           // as numCorrect and numWrong are calculated
-          this.numSkipped = this.numItems
-          this.plioDBId = plioDetails.plioDBId
-          this.videoId = this.getVideoIDfromURL(plioDetails.videoURL)
-          this.plioTitle = plioDetails.plioTitle
+          this.numSkipped = this.numItems;
+          this.plioDBId = plioDetails.plioDBId;
+          this.videoId = this.getVideoIDfromURL(plioDetails.videoURL);
+          this.plioTitle = plioDetails.plioTitle;
           this.plioSettings = SettingsUtilities.setPlioSettings(
             plioDetails.config
-          )
+          );
         })
         .then(() => this.createSession())
-        .then(() => this.logData())
+        .then(() => this.logData());
     },
     /**
      * periodically logs data to the server
@@ -838,37 +849,37 @@ export default {
        * do not log data if the user is not authenticated
        * or if the plio is opened in preview mode
        */
-      if (!this.isAuthenticated || this.previewMode) return
+      if (!this.isAuthenticated || this.previewMode) return;
 
       if (this.hasSessionStarted) {
         // update session data
-        this.updateSession()
+        this.updateSession();
         // if a 'watching' event exists for the current session, update that event
         // else create a new event
-        if (this.watchingEventDBId == null) this.createEvent("watching")
-        else this.updateEvent("watching", this.watchingEventDBId)
+        if (this.watchingEventDBId == null) this.createEvent("watching");
+        else this.updateEvent("watching", this.watchingEventDBId);
 
         this.$mixpanel.people.increment(
           "Total Watch Time",
           this.watchTimeIncrement.toFixed(2)
-        )
-        this.watchTimeIncrement = 0
+        );
+        this.watchTimeIncrement = 0;
       }
-      UPLOAD_INTERVAL_TIMEOUT = setTimeout(this.logData, UPLOAD_INTERVAL)
+      UPLOAD_INTERVAL_TIMEOUT = setTimeout(this.logData, UPLOAD_INTERVAL);
     },
     closeItemModal() {
       // invoked when the modal is to be closed
-      this.currentItemIndex = null
-      this.toast.dismiss("cannotSkipItem")
-      this.playPlayer()
+      this.currentItemIndex = null;
+      this.toast.dismiss("cannotSkipItem");
+      this.playPlayer();
     },
     playPlayer() {
       // plays the video player
-      this.player.play()
+      this.player.play();
     },
     pausePlayer() {
       // pauses the video player
-      this.player.pause()
+      this.player.pause();
     },
     /**
      * creates new user-plio session
@@ -884,57 +895,57 @@ export default {
           if (this.isItemMCQ(itemIndex)) {
             this.itemResponses.push({
               answer: NaN
-            })
+            });
           } else {
             this.itemResponses.push({
               answer: null
-            })
+            });
           }
-        })
-        return
+        });
+        return;
       }
 
       SessionAPIService.createSession(this.plioDBId).then((sessionDetails) => {
-        this.sessionDBId = sessionDetails.id
+        this.sessionDBId = sessionDetails.id;
         // reset the user to where they left off if they are returning
         if (sessionDetails.last_event != null) {
-          this.currentTimestamp = sessionDetails.last_event.player_time
+          this.currentTimestamp = sessionDetails.last_event.player_time;
         }
 
         // if this is the first session for this plio-user combination
         // increment the number of plios watched by this user
         if (sessionDetails.is_first) {
-          this.$mixpanel.people.increment("Total Plios Viewed")
+          this.$mixpanel.people.increment("Total Plios Viewed");
         }
 
         // handle retention array
-        this.retention = this.retentionStrToArray(sessionDetails.retention)
+        this.retention = this.retentionStrToArray(sessionDetails.retention);
 
         // set watch time
-        this.watchTime = sessionDetails.watch_time
+        this.watchTime = sessionDetails.watch_time;
 
         // set item responses
         sessionDetails.session_answers.forEach((sessionAnswer, itemIndex) => {
           // removing the _id in keys like session_id, question_id
           // so that we can directly update the answers without having to
           // create another dictionary every time we want to upload
-          let itemResponse = {}
+          let itemResponse = {};
           for (let key of Object.keys(sessionAnswer)) {
-            itemResponse[key.replace("_id", "")] = sessionAnswer[key]
+            itemResponse[key.replace("_id", "")] = sessionAnswer[key];
           }
           // for mcq items, convert answers to integer
           if (this.isItemMCQ(itemIndex)) {
-            itemResponse.answer = parseInt(itemResponse.answer)
+            itemResponse.answer = parseInt(itemResponse.answer);
           }
-          this.itemResponses.push(itemResponse)
-        })
+          this.itemResponses.push(itemResponse);
+        });
         if (!this.isSkipEnabled) {
           // set the last answered item index
           for (let [itemIndex, itemResponse] of this.itemResponses.entries()) {
             if (!this.isItemResponseEmpty(itemIndex, itemResponse.answer))
-              this.lastAnsweredItemIndex = itemIndex
+              this.lastAnsweredItemIndex = itemIndex;
             // https://github.com/avantifellows/plio-frontend/pull/629#issuecomment-1053819610
-            else break
+            else break;
           }
 
           // check if any item before the current timestamp is unanswered
@@ -942,12 +953,12 @@ export default {
           // unanswered item
           if (!this.isMovingToTimestampAllowed(this.currentTimestamp)) {
             this.currentTimestamp =
-              this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY
+              this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY;
           }
         }
         // once itemResponses is full, calculate all the scorecard metrics
-        this.calculateScorecardMetrics()
-      })
+        this.calculateScorecardMetrics();
+      });
     },
     /**
      * updates the session data on the server
@@ -957,34 +968,34 @@ export default {
        * do not try updating the session if the user is not authenticated
        * or if the plio is opened in preview mode
        */
-      if (!this.isAuthenticated || this.previewMode) return
+      if (!this.isAuthenticated || this.previewMode) return;
 
       return SessionAPIService.updateSession(this.sessionDBId, {
         plio: this.plioDBId,
         watch_time: this.watchTime,
         retention: this.retentionArrayToStr(this.retention)
-      }).catch((err) => console.log(err))
+      }).catch((err) => console.log(err));
     },
     retentionStrToArray(retentionStr) {
       // convert retention string to retention array
-      return retentionStr.split(",").map((value) => parseInt(value))
+      return retentionStr.split(",").map((value) => parseInt(value));
     },
     retentionArrayToStr(retentionArray) {
       // convert retention array to retention string
-      return retentionArray.join(",")
+      return retentionArray.join(",");
     },
     getVideoIDfromURL(videoURL) {
       // gets the video Id from the YouTube URL
       let linkValidation =
-        VideoFunctionalService.isYouTubeVideoLinkValid(videoURL)
-      return linkValidation["ID"]
+        VideoFunctionalService.isYouTubeVideoLinkValid(videoURL);
+      return linkValidation["ID"];
     },
     playerPlayed() {
       if (this.moveToFirstUnansweredItemOrPass()) {
-        this.pausePlayer()
+        this.pausePlayer();
 
-        if (this.isAnyItemActive) this.maximizeModal()
-        return
+        if (this.isAnyItemActive) this.maximizeModal();
+        return;
       }
 
       // invoked when the play button of the player is clicked
@@ -993,40 +1004,40 @@ export default {
          * prevents the video from playing while the
          * scorecard is being shown
          */
-        this.pausePlayer()
-        return
+        this.pausePlayer();
+        return;
       }
-      this.createEvent("played")
+      this.createEvent("played");
     },
     playerPaused() {
       // invoked when the pause button of the player is clicked
-      this.createEvent("paused")
+      this.createEvent("paused");
     },
     playerInitiated() {
       // sets the aspect ratio while the player is getting ready
-      this.setPlayerAspectRatio()
-      this.$emit("initiated")
+      this.setPlayerAspectRatio();
+      this.$emit("initiated");
     },
     /**
      * sets the current time of the player to the given time
      * @param {Number} timestamp
      */
     setPlayerTime(timestamp) {
-      this.player.currentTime = timestamp
+      this.player.currentTime = timestamp;
     },
     playerReady() {
       // invoked when the player is ready
-      this.showItemMarkersOnSlider()
+      this.showItemMarkersOnSlider();
       // only show the scorecard when items are present in the plio
-      if (this.isScorecardEnabled) this.showScorecardMarkerOnSlider()
-      this.setPlayerTime(this.currentTimestamp)
+      if (this.isScorecardEnabled) this.showScorecardMarkerOnSlider();
+      this.setPlayerTime(this.currentTimestamp);
       this.$mixpanel.track("Visit Player", {
         "Plio UUID": this.plioId,
         "Plio Video Length": this.player.duration || 0,
         "Plio Num Items": this.numItems || 0
-      })
+      });
       // sets various properties based on the screen size
-      this.setScreenProperties()
+      this.setScreenProperties();
 
       // disabling autoplay because of bug - issue #157
       // this.playPlayer();
@@ -1038,11 +1049,11 @@ export default {
      * @param {Number} positionPercent - By what % from the left should the marker be placed
      */
     placeMarkerOnSlider(marker, classList, positionPercent) {
-      let plyrProgressBar = document.querySelectorAll(".plyr__progress")[0]
+      let plyrProgressBar = document.querySelectorAll(".plyr__progress")[0];
       if (plyrProgressBar != undefined) {
-        marker.classList.add(...classList)
-        marker.style.setProperty("left", `${positionPercent}%`)
-        plyrProgressBar.appendChild(marker)
+        marker.classList.add(...classList);
+        marker.style.setProperty("left", `${positionPercent}%`);
+        plyrProgressBar.appendChild(marker);
       }
     },
     /**
@@ -1050,9 +1061,9 @@ export default {
      * @param {Object} marker - The HTML element that needs to be removed from the progress bar
      */
     removeMarkerOnSlider(marker) {
-      var plyrProgressBar = document.querySelectorAll(".plyr__progress")[0]
+      var plyrProgressBar = document.querySelectorAll(".plyr__progress")[0];
       if (plyrProgressBar != undefined) {
-        plyrProgressBar.removeChild(marker)
+        plyrProgressBar.removeChild(marker);
       }
     },
     /**
@@ -1061,48 +1072,50 @@ export default {
      */
     showItemMarkersOnSlider() {
       this.items.forEach((item, index) => {
-        let existingMarker = document.getElementById(`plioModalMarker-${index}`)
+        let existingMarker = document.getElementById(
+          `plioModalMarker-${index}`
+        );
         if (existingMarker != undefined)
-          this.removeMarkerOnSlider(existingMarker)
+          this.removeMarkerOnSlider(existingMarker);
 
         // add marker to player seek bar
-        let newMarker = document.createElement("SPAN")
-        newMarker.setAttribute("id", `plioModalMarker-${index}`)
+        let newMarker = document.createElement("SPAN");
+        newMarker.setAttribute("id", `plioModalMarker-${index}`);
 
         // set marker style and position
         if (this.isItemResponseDone(index)) {
-          this.markerClass[0] = "bg-green-600"
-        } else this.markerClass[0] = "bg-red-600"
+          this.markerClass[0] = "bg-green-600";
+        } else this.markerClass[0] = "bg-red-600";
 
-        let positionPercent = (100 * item.time) / this.player.duration
+        let positionPercent = (100 * item.time) / this.player.duration;
 
-        this.placeMarkerOnSlider(newMarker, this.markerClass, positionPercent)
-      })
+        this.placeMarkerOnSlider(newMarker, this.markerClass, positionPercent);
+      });
     },
     /**
      * Place the marker emoji for scorecard on the plyr progress bar
      */
     showScorecardMarkerOnSlider() {
       // add marker to player seek bar
-      let newMarker = document.createElement("p")
-      newMarker.setAttribute("id", `plioScorecardMarker`)
+      let newMarker = document.createElement("p");
+      newMarker.setAttribute("id", `plioScorecardMarker`);
 
       // what the marker should look like - trophy cup emoji
-      newMarker.innerText = "🏆"
+      newMarker.innerText = "🏆";
 
       // set marker position
 
-      this.placeMarkerOnSlider(newMarker, this.scorecardMarkerClass, 100)
+      this.placeMarkerOnSlider(newMarker, this.scorecardMarkerClass, 100);
     },
     isItemResponseDone(itemIndex) {
       // whether the response to an item is complete
       if (this.itemResponses && this.itemResponses[itemIndex]) {
-        if (this.itemResponses[itemIndex].answer == null) return false
+        if (this.itemResponses[itemIndex].answer == null) return false;
         if (this.isItemMCQ(itemIndex))
-          return !isNaN(this.itemResponses[itemIndex].answer)
-        return true
+          return !isNaN(this.itemResponses[itemIndex].answer);
+        return true;
       }
-      return false
+      return false;
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
@@ -1111,7 +1124,7 @@ export default {
       return (
         this.isItemQuestion(itemIndex) &&
         this.itemDetails[itemIndex].type == "mcq"
-      )
+      );
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
@@ -1120,7 +1133,7 @@ export default {
       return (
         this.isItemQuestion(itemIndex) &&
         this.itemDetails[itemIndex].type == "checkbox"
-      )
+      );
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
@@ -1129,29 +1142,29 @@ export default {
       return (
         this.isItemQuestion(itemIndex) &&
         this.itemDetails[itemIndex].type == "subjective"
-      )
+      );
     },
     /**
      * @param {Number} itemIndex - index of an item in the items array
      */
     isItemQuestion(itemIndex) {
-      return this.items[itemIndex].type == "question"
+      return this.items[itemIndex].type == "question";
     },
     /**
      * invoked when the current time in the video is updated
      */
     videoTimestampUpdated(timestamp) {
       // check if popups should be shown at the given timestamp or not
-      this.checkForPopups(timestamp)
+      this.checkForPopups(timestamp);
 
       // update watch time
-      this.watchTime += PLYR_INTERVAL_TIME
-      this.watchTimeIncrement += PLYR_INTERVAL_TIME
+      this.watchTime += PLYR_INTERVAL_TIME;
+      this.watchTimeIncrement += PLYR_INTERVAL_TIME;
       // update retention if the array is defined
-      let currentTime = Math.trunc(this.player.currentTime)
+      let currentTime = Math.trunc(this.player.currentTime);
       if (currentTime != this.lastTimestampRetention && this.retention.length) {
-        this.retention[currentTime] += 1
-        this.lastTimestampRetention = currentTime
+        this.retention[currentTime] += 1;
+        this.lastTimestampRetention = currentTime;
       }
     },
     /**
@@ -1163,13 +1176,13 @@ export default {
         Math.abs(timestamp - this.lastCheckTimestamp) <
         POP_UP_CHECKING_FREQUENCY
       )
-        return
-      this.lastCheckTimestamp = timestamp
-      if (!this.isAspectRatioChecked) this.checkAndSetPlayerAspectRatio()
+        return;
+      this.lastCheckTimestamp = timestamp;
+      if (!this.isAspectRatioChecked) this.checkAndSetPlayerAspectRatio();
 
-      const itemIndex = this.checkForItemPopup(timestamp)
+      const itemIndex = this.checkForItemPopup(timestamp);
       if (itemIndex != null) {
-        this.currentItemIndex = itemIndex
+        this.currentItemIndex = itemIndex;
 
         // show an error toast indicating that the user
         // has to answer the current item before moving ahead
@@ -1177,13 +1190,13 @@ export default {
           this.toast.error(`☝️ ${this.$t("toast.player.cannot_skip_item")}`, {
             id: "cannotSkipItem",
             position: "bottom-center"
-          })
-          this.showItemPopUpErrorToast = false
+          });
+          this.showItemPopUpErrorToast = false;
         }
-        this.markItemSelected()
-        this.createEvent("item_opened", { itemIndex: this.currentItemIndex })
+        this.markItemSelected();
+        this.createEvent("item_opened", { itemIndex: this.currentItemIndex });
       } else {
-        this.closeItemModal()
+        this.closeItemModal();
       }
     },
     /**
@@ -1191,35 +1204,35 @@ export default {
      * @param {Number} timestamp - The player's current timestamp in seconds
      */
     checkForItemPopup(timestamp) {
-      this.maximizeModal()
+      this.maximizeModal();
       return ItemFunctionalService.checkItemPopup(
         timestamp,
         this.itemTimestamps,
         POP_UP_PRECISION_TIME
-      )
+      );
     },
     markItemSelected() {
       // mark the item at the currentItemIndex as selected
-      this.pausePlayer()
+      this.pausePlayer();
 
       // if the video is in fullscreen mode, show the modal on top of it
-      let modal = document.getElementById(this.plioModalElementId)
-      if (modal != undefined) this.mountOnFullscreenPlyr(modal)
+      let modal = document.getElementById(this.plioModalElementId);
+      if (modal != undefined) this.mountOnFullscreenPlyr(modal);
 
-      let maximizeButton = document.getElementById("plioMaximizeButton")
+      let maximizeButton = document.getElementById("plioMaximizeButton");
       if (maximizeButton != undefined)
-        this.mountOnFullscreenPlyr(maximizeButton)
+        this.mountOnFullscreenPlyr(maximizeButton);
     },
     enterPlayerFullscreen() {
       // sets the player to fullscreen
-      this.isFullscreen = true
-      this.createEvent("enter_fullscreen")
+      this.isFullscreen = true;
+      this.createEvent("enter_fullscreen");
     },
     exitPlayerFullscreen() {
       // unsets the player from fullscreen
-      this.isFullscreen = false
-      this.createEvent("exit_fullscreen")
-      this.setPlayerAspectRatio()
+      this.isFullscreen = false;
+      this.createEvent("exit_fullscreen");
+      this.setPlayerAspectRatio();
     },
     /**
      * creates a new event
@@ -1233,15 +1246,15 @@ export default {
        * in preview mode
        */
       if (!this.hasSessionStarted || !this.isAuthenticated || this.previewMode)
-        return
+        return;
       let response = await EventAPIService.createEvent({
         type: eventType,
         details: eventDetails,
         player_time:
           this.player.currentTime != null ? this.player.currentTime : 0,
         session: this.sessionDBId
-      })
-      if (eventType == "watching") this.watchingEventDBId = response.id
+      });
+      if (eventType == "watching") this.watchingEventDBId = response.id;
     },
     /**
      * Updates an event
@@ -1256,14 +1269,14 @@ export default {
         player_time:
           this.player.currentTime != null ? this.player.currentTime : 0,
         session: this.sessionDBId
-      })
+      });
     },
     goFullscreen() {
-      this.isFullscreen = true
+      this.isFullscreen = true;
     }
   },
   emits: ["initiated", "loaded", "item-toggle"]
-}
+};
 </script>
 
 <style lang="scss">

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -532,7 +532,12 @@ export default {
   },
   methods: {
     ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
-
+    isItemResponseEmpty(itemIndex, answer) {
+      if (answer == null) return true;
+      if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer);
+      if (this.itemDetails[itemIndex].type == "checkbox") return answer.length == 0;
+      return false;
+    },
     /**
      * sets various properties based on the screen size
      */
@@ -904,8 +909,7 @@ export default {
             itemResponse.answer = parseInt(itemResponse.answer);
           }
           if (
-            itemResponse.answer != null &&
-            !isNaN(itemResponse.answer) &&
+            !this.isItemResponseEmpty(itemIndex, itemResponse.answer) &&
             !this.isSkipEnabled
           ) {
             this.lastAnsweredInteractionIndex = itemIndex;

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -931,10 +931,10 @@ export default {
     },
     playerPlayed() {
       // invoked when the play button of the player is clicked
-      if (this.isScorecardShown) {
+      if (this.isScorecardShown || (!this.isSkipEnabled && this.isAnyItemActive)) {
         /**
          * prevents the video from playing while the
-         * scorecard is being shown
+         * scorecard is being shown or when an item is active with skip disabled
          */
         this.pausePlayer();
         return;

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -961,13 +961,7 @@ export default {
       if (this.moveToFirstUnansweredItemOrPass()) {
         this.pausePlayer()
 
-        if (this.isAnyItemActive) {
-          this.maximizeModal()
-          this.toast.error(`☝️ ${this.$t('toast.player.cannot_skip_item')}`, {
-            id: 'cannotSkipItem',
-            position: 'bottom-center'
-          })
-        }
+        if (this.isAnyItemActive) this.maximizeModal()
         return
       }
 

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -677,18 +677,19 @@ export default {
     },
     checkMovingToTimestampAllowed(timestamp) {
       if (!this.isSkipEnabled && this.lastAnsweredInteractionIndex < this.numItems - 1) {
-        const lastUnansweredInteraction = this.items[
+        const firstUnansweredInteraction = this.items[
           this.lastAnsweredInteractionIndex + 1
         ];
-        if (timestamp > lastUnansweredInteraction.time) return lastUnansweredInteraction;
+        if (timestamp > firstUnansweredInteraction.time)
+          return firstUnansweredInteraction;
       }
     },
     videoSeeked() {
-      const lastUnansweredInteraction = this.checkMovingToTimestampAllowed(
+      const firstUnansweredInteraction = this.checkMovingToTimestampAllowed(
         this.player.currentTime
       );
-      if (lastUnansweredInteraction != null) {
-        this.setPlayerTime(lastUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY);
+      if (firstUnansweredInteraction != null) {
+        this.setPlayerTime(firstUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY);
         setTimeout(() => {
           this.toast.error(this.$t("toast.player.cannot_skip_interaction"), {
             id: "internetLostToast",
@@ -882,12 +883,12 @@ export default {
           this.itemResponses.push(itemResponse);
         });
         if (!this.isSkipEnabled) {
-          const lastUnansweredInteraction = this.checkMovingToTimestampAllowed(
+          const firstUnansweredInteraction = this.checkMovingToTimestampAllowed(
             this.currentTimestamp
           );
-          if (lastUnansweredInteraction != null) {
+          if (firstUnansweredInteraction != null) {
             this.currentTimestamp =
-              lastUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;
+              firstUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;
           }
         }
         // once itemResponses is full, calculate all the scorecard metrics

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -209,7 +209,7 @@ export default {
       isAspectRatioChecked: false, // whether the check for aspect ratio has been done
       watchingEventDBId: null, // the DB id of the latest 'watching' event for a given session
       plioSettings: null, // stores this plio's settings
-      lastAnsweredItemIndex: -1, // index of the interaction that was last answered
+      lastAnsweredItemIndex: -1, // index of the item that was last answered
       showItemPopUpErrorToast: false, // whether to show the error toast when an item is opened
     };
   },
@@ -544,6 +544,10 @@ export default {
   },
   methods: {
     ...mapActions("auth", ["setAccessToken", "setActiveWorkspace"]),
+    /**
+     * @param {Number} itemIndex - the index of the item whose response is to be checked
+     * @param {Number} answer - the response to be checked
+     */
     isItemResponseEmpty(itemIndex, answer) {
       if (answer == null) return true;
       if (this.itemDetails[itemIndex].type == "mcq") return isNaN(answer);
@@ -704,14 +708,18 @@ export default {
           this.mountOnFullscreenPlyr(maximizeButton);
       });
     },
+    /**
+     * @param {Number} timestamp - the timestamp to be checked
+     */
     isMovingToTimestampAllowed(timestamp) {
       if (this.firstUnansweredItem == null) return true;
-      // check whether skip is disabled and all items have been answered
+      // comes here only when skip is disabled and there are unanswered items
+      // at times before the timestamp given
       return timestamp < this.firstUnansweredItem.time;
     },
     /**
      * whether the user should be moved to the first unanswered item
-     * or allowed to pass through to whatever timestamp they are trying to
+     * or is allowed to pass through to whatever timestamp they are trying to
      * go to
      */
     moveToFirstUnansweredItemOrPass() {
@@ -721,9 +729,9 @@ export default {
       /**
        * this is required to handle the case that the user toggles
        * the show video/question button while an item is active and tries
-       * to play the video since the user will be in the time range of item
-       * timestamp and item timestamp - POP_UP_CHECKING_FREQUENCY, the code
-       * after this snippet will function incorrectly
+       * to play the video. Since the user will be in the time range of item
+       * timestamp and item timestamp - POP_UP_CHECKING_FREQUENCY, without
+       * this snippet, the code following it will function incorrectly
        */
       if (
         this.isAnyItemActive &&

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -881,12 +881,14 @@ export default {
           }
           this.itemResponses.push(itemResponse);
         });
-        const lastUnansweredInteraction = this.checkMovingToTimestampAllowed(
-          this.currentTimestamp
-        );
-        if (lastUnansweredInteraction != null) {
-          this.currentTimestamp =
-            lastUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;
+        if (!this.isSkipEnabled) {
+          const lastUnansweredInteraction = this.checkMovingToTimestampAllowed(
+            this.currentTimestamp
+          );
+          if (lastUnansweredInteraction != null) {
+            this.currentTimestamp =
+              lastUnansweredInteraction.time - POP_UP_CHECKING_FREQUENCY;
+          }
         }
         // once itemResponses is full, calculate all the scorecard metrics
         this.calculateScorecardMetrics();

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -878,7 +878,11 @@ export default {
           if (this.isItemMCQ(itemIndex)) {
             itemResponse.answer = parseInt(itemResponse.answer);
           }
-          if (itemResponse.answer != null && !isNaN(itemResponse.answer)) {
+          if (
+            itemResponse.answer != null &&
+            !isNaN(itemResponse.answer) &&
+            !this.isSkipEnabled
+          ) {
             this.lastAnsweredInteractionIndex = itemIndex;
           }
           this.itemResponses.push(itemResponse);

--- a/src/pages/Embeds/Plio.vue
+++ b/src/pages/Embeds/Plio.vue
@@ -698,7 +698,7 @@ export default {
      * or allowed to pass through to whatever timestamp they are trying to
      * go to
      */
-    moveToFirstUnansweredItemTimestampOrPass() {
+    moveToFirstUnansweredItemOrPass() {
       if (this.isSkipEnabled) return false
       let timeToInspect = this.player.currentTime
 
@@ -720,20 +720,9 @@ export default {
 
       // move to first unanswered item
       this.setPlayerTime(this.firstUnansweredItem.time - POP_UP_CHECKING_FREQUENCY)
-      setTimeout(() => {
-        this.toast.error(`☝️ ${this.$t('toast.player.cannot_skip_item')}`, {
-          id: 'cannotSkipItem',
-          position: 'bottom-center'
-        })
-      }, 500)
       return true
     },
     videoSeeked() {
-      if (this.moveToFirstUnansweredItemTimestampOrPass()) {
-        this.isModalMinimized = false
-        return
-      }
-
       // invoked when a seek operation ends
       this.createEvent('video_seeked', { currentTime: this.player.currentTime })
     },
@@ -967,8 +956,13 @@ export default {
       return linkValidation['ID']
     },
     playerPlayed() {
-      if (this.moveToFirstUnansweredItemTimestampOrPass()) {
+      if (this.moveToFirstUnansweredItemOrPass()) {
         this.pausePlayer()
+        this.maximizeModal()
+        this.toast.error(`☝️ ${this.$t('toast.player.cannot_skip_item')}`, {
+          id: 'cannotSkipItem',
+          position: 'bottom-center'
+        })
         return
       }
 
@@ -1156,7 +1150,7 @@ export default {
      * @param {Number} timestamp - The player's current timestamp in seconds
      */
     checkForItemPopup(timestamp) {
-      this.isModalMinimized = false
+      this.maximizeModal()
       return ItemFunctionalService.checkItemPopup(
         timestamp,
         this.itemTimestamps,

--- a/tests/unit/pages/embeds/Plio.spec.js
+++ b/tests/unit/pages/embeds/Plio.spec.js
@@ -5,6 +5,7 @@ import store from "@/store";
 import router from "@/router";
 import UserAPIService from "@/services/API/User.js";
 import EventAPIService from "@/services/API/Event.js";
+import SettingsUtilities from "@/services/Functional/Utilities/Settings.js";
 import { userFromTokenEndpoint } from "@/services/API/Endpoints";
 
 let clonedeep = require("lodash.clonedeep");
@@ -14,7 +15,12 @@ let plioId = "123";
 let setPlayerAspectRatio;
 
 const mountWrapper = async (
-  params = { loadPlio: false, props: {}, data: {} }
+  params = {
+    loadPlio: false,
+    props: {},
+    data: {},
+    dummyPlio: global.dummyPublishedPlio,
+  }
 ) => {
   if (wrapper != undefined) await wrapper.unmount();
   setPlayerAspectRatio = jest
@@ -33,17 +39,14 @@ const mountWrapper = async (
   await flushPromises();
 
   if (params.loadPlio) {
-    await loadPlio();
+    await loadPlio(params.dummyPlio);
   }
 };
 
-const loadPlio = async () => {
+const loadPlio = async (dummyPlio = global.dummyPublishedPlio) => {
   // resolve the `GET` request waiting in the queue (for receiving plio details)
   // using the fake response data
-  mockAxios.mockResponse(
-    clonedeep(global.dummyPublishedPlio),
-    mockAxios.queue()[0]
-  );
+  mockAxios.mockResponse(clonedeep(dummyPlio), mockAxios.queue()[0]);
 
   // wait until the DOM updates after promises resolve
   await flushPromises();
@@ -84,121 +87,6 @@ describe("Plio.vue", () => {
     // 1 `GET` request is made
     expect(mockAxios.get).toHaveBeenCalledTimes(1);
     expect(mockAxios.get).toHaveBeenCalledWith(`/plios/${plioId}/play`);
-  });
-
-  it("renders plio when plio details are passed", async () => {
-    const playerInitiated = jest.spyOn(Plio.methods, "playerInitiated");
-    await mountWrapper({ loadPlio: true });
-
-    expect(wrapper.vm.isPlioLoaded).toBeTruthy();
-    expect(wrapper.items).toStrictEqual(global.dummyPublishedPlio.items);
-    expect(setPlayerAspectRatio).toHaveBeenCalled();
-    expect(playerInitiated).toHaveBeenCalled();
-  });
-
-  it("sets properties based on screen size when player is ready", async () => {
-    const mockPlyrVolumeElement = [
-      {
-        style: {
-          display: "",
-        },
-      },
-    ];
-
-    const playerReady = jest.spyOn(Plio.methods, "playerReady");
-    const setPlayerTime = jest
-      .spyOn(Plio.methods, "setPlayerTime")
-      .mockImplementation(() => jest.fn());
-    const setScreenProperties = jest.spyOn(Plio.methods, "setScreenProperties");
-
-    const setPlayerVolumeVisibility = jest.spyOn(
-      Plio.methods,
-      "setPlayerVolumeVisibility"
-    );
-
-    await mountWrapper({ loadPlio: true });
-
-    // mock plyr width > 640
-    global.document.getElementById = jest.fn(() => ({
-      clientWidth: 700,
-      getElementsByClassName: () => {
-        return mockPlyrVolumeElement;
-      },
-    }));
-
-    wrapper.vm.$refs.videoPlayer.$emit("ready");
-
-    expect(playerReady).toHaveBeenCalled();
-    expect(setScreenProperties).toHaveBeenCalled();
-    expect(setPlayerTime).toHaveBeenCalled();
-    expect(setPlayerAspectRatio).toHaveBeenCalled();
-    expect(setPlayerVolumeVisibility).toHaveBeenCalled();
-    expect(mockPlyrVolumeElement[0].style.display).toBe("flex");
-
-    // mock plyr width < 640
-    global.document.getElementById = jest.fn(() => ({
-      clientWidth: 500,
-      getElementsByClassName: () => {
-        return mockPlyrVolumeElement;
-      },
-    }));
-
-    wrapper.vm.$refs.videoPlayer.$emit("ready");
-
-    expect(mockPlyrVolumeElement[0].style.display).toBe("none");
-  });
-
-  describe("session creation", () => {
-    it("session should not be created if unauthenticated when plio request is resolved", async () => {
-      const createSession = jest.spyOn(Plio.methods, "createSession");
-      await mountWrapper({ loadPlio: true });
-
-      expect(createSession).toHaveBeenCalled();
-
-      // 0 `POST` request should have been made
-      expect(mockAxios.post).toHaveBeenCalledTimes(0);
-    });
-
-    describe("authenticated user", () => {
-      beforeEach(async () => {
-        await authenticateUser();
-      });
-      it("creates session when plio request is resolved", async () => {
-        await mountWrapper({ loadPlio: true });
-
-        // 1 `POST` request should have been made
-        expect(mockAxios.post).toHaveBeenCalledTimes(1);
-        expect(mockAxios.post).toHaveBeenCalledWith("/sessions/", {
-          plio: global.dummyPublishedPlio.data.id,
-        });
-      });
-
-      it("populates item responses when request to fetch sessions is resolved", async () => {
-        await mountWrapper({ loadPlio: true });
-        mockAxios.mockResponse(
-          clonedeep(global.dummySession),
-          mockAxios.queue()[0]
-        );
-        expect(wrapper.vm.itemResponses.length).toBe(
-          global.dummyItemResponses.length
-        );
-        expect(wrapper.vm.numCorrect).toBe(4);
-        expect(wrapper.vm.numWrong).toBe(1);
-        expect(wrapper.vm.numSkipped).toBe(0);
-      });
-
-      it("does not create session if opened in preview mode", async () => {
-        await mountWrapper();
-        await wrapper.setProps({
-          previewMode: true,
-        });
-
-        await loadPlio();
-
-        // 0 `POST` request should have been made
-        expect(mockAxios.post).toHaveBeenCalledTimes(0);
-      });
-    });
   });
 
   describe("SAML SSO", () => {
@@ -265,128 +153,251 @@ describe("Plio.vue", () => {
     });
   });
 
-  it("checks for aspect ratio when the player has buffered", async () => {
-    const checkAndSetPlayerAspectRatio = jest.spyOn(
-      Plio.methods,
-      "checkAndSetPlayerAspectRatio"
-    );
-
-    await mountWrapper({ loadPlio: true });
-
-    // aspect ratio shouldn't have been checked at the start
-    expect(wrapper.vm.isAspectRatioChecked).toBeFalsy();
-
-    wrapper.vm.$refs.videoPlayer.$emit("buffered");
-
-    expect(checkAndSetPlayerAspectRatio).toHaveBeenCalled();
-    expect(wrapper.vm.isAspectRatioChecked).toBeTruthy();
-  });
-
-  describe("event updates", () => {
-    let watchingEventDBId = 1;
-
-    it("calls updateEvent method for consecutive 'watching' events for a given session", async () => {
-      // mock createSession method
-      jest.spyOn(Plio.methods, "createSession").mockImplementation(() => {
-        return new Promise((resolve) => resolve());
-      });
-
-      // mock updateEvent method
-      let updateEvent = jest
-        .spyOn(Plio.methods, "updateEvent")
-        .mockImplementation(() => {
-          return;
-        });
-
-      await authenticateUser();
-
-      // simulating the case where a 'watching' event has already been created
-      await mountWrapper({
-        loadPlio: true,
-        data: {
-          watchingEventDBId: watchingEventDBId,
-          sessionDBId: 1,
-        },
-      });
-
-      // assert that updateEvent method has been called with the correct params
-      expect(updateEvent).toHaveBeenCalledWith("watching", watchingEventDBId);
-    });
-
-    it("updates a watching event when updateEvent is called", () => {
-      // spy on the updateEvent method inside EventAPIService
-      let updateEventAPICall = jest.spyOn(EventAPIService, "updateEvent");
-
-      // Testing the individual method using 'call'
-      // refer to this - https://lmiller1990.github.io/vue-testing-handbook/v3/computed-properties.html#testing-with-call
-      // build a local context object - localThis. It will serve as 'this' in our test.
-      let localThis = {
-        hasSessionStarted: true,
-        isAuthenticated: true,
-        previewMode: false,
-        sessionDBId: 3,
-        player: {
-          currentTime: 10,
-        },
-      };
-
-      let eventType = "watching";
-
-      // invoke the method using the local context object and appropriate params
-      Plio.methods.updateEvent.call(localThis, eventType, watchingEventDBId);
-
-      // the updateEvent method inside EventAPIService would've been called
-      // An update request would've been made with the correct payload
-      expect(updateEventAPICall).toHaveBeenCalled();
-      expect(mockAxios.put).toHaveBeenCalledTimes(1);
-      expect(mockAxios.put).toHaveBeenCalledWith(
-        `/events/${watchingEventDBId}`,
-        {
-          type: eventType,
-          details: {},
-          player_time: localThis.player.currentTime,
-          session: localThis.sessionDBId,
-        }
-      );
-    });
-  });
-  describe("submitting question", () => {
-    let createEvent;
-
-    const setupWrapper = async (params = { currentItemIndex: 0 }) => {
-      await mountWrapper({
-        loadPlio: true,
-        data: {
-          currentItemIndex: params.currentItemIndex,
-          itemResponses: clonedeep(global.dummyItemResponses),
-        },
-      });
-    };
+  describe("plio loaded", () => {
+    let playerInitiated;
+    let checkAndSetPlayerAspectRatio;
 
     beforeEach(async () => {
-      createEvent = jest.spyOn(Plio.methods, "createEvent");
-      await setupWrapper();
+      playerInitiated = jest.spyOn(Plio.methods, "playerInitiated");
+      checkAndSetPlayerAspectRatio = jest.spyOn(
+        Plio.methods,
+        "checkAndSetPlayerAspectRatio"
+      );
+      await mountWrapper({ loadPlio: true });
     });
 
-    it("does not make an API call if the user is not authenticated", async () => {
-      wrapper.vm.$refs.plioModal.$emit("submit-question");
-      expect(mockAxios.put).not.toHaveBeenCalled();
-      expect(createEvent).not.toHaveBeenCalled();
+    it("renders plio when plio details are passed", async () => {
+      expect(wrapper.vm.isPlioLoaded).toBeTruthy();
+      expect(wrapper.items).toStrictEqual(global.dummyPublishedPlio.items);
+      expect(setPlayerAspectRatio).toHaveBeenCalled();
+      expect(playerInitiated).toHaveBeenCalled();
     });
 
-    it("does not make an API call if in preview mode", async () => {
-      await wrapper.setProps({
-        previewMode: true,
+    it("sets properties based on screen size when player is ready", async () => {
+      const mockPlyrVolumeElement = [
+        {
+          style: {
+            display: "",
+          },
+        },
+      ];
+
+      const playerReady = jest.spyOn(Plio.methods, "playerReady");
+      const setPlayerTime = jest
+        .spyOn(Plio.methods, "setPlayerTime")
+        .mockImplementation(() => jest.fn());
+      const setScreenProperties = jest.spyOn(
+        Plio.methods,
+        "setScreenProperties"
+      );
+
+      const setPlayerVolumeVisibility = jest.spyOn(
+        Plio.methods,
+        "setPlayerVolumeVisibility"
+      );
+
+      await mountWrapper({ loadPlio: true });
+
+      // mock plyr width > 640
+      global.document.getElementById = jest.fn(() => ({
+        clientWidth: 700,
+        getElementsByClassName: () => {
+          return mockPlyrVolumeElement;
+        },
+      }));
+
+      wrapper.vm.$refs.videoPlayer.$emit("ready");
+
+      expect(playerReady).toHaveBeenCalled();
+      expect(setScreenProperties).toHaveBeenCalled();
+      expect(setPlayerTime).toHaveBeenCalled();
+      expect(setPlayerAspectRatio).toHaveBeenCalled();
+      expect(setPlayerVolumeVisibility).toHaveBeenCalled();
+      expect(mockPlyrVolumeElement[0].style.display).toBe("flex");
+
+      // mock plyr width < 640
+      global.document.getElementById = jest.fn(() => ({
+        clientWidth: 500,
+        getElementsByClassName: () => {
+          return mockPlyrVolumeElement;
+        },
+      }));
+
+      wrapper.vm.$refs.videoPlayer.$emit("ready");
+
+      expect(mockPlyrVolumeElement[0].style.display).toBe("none");
+    });
+
+    it("checks for aspect ratio when the player has buffered", async () => {
+      // aspect ratio shouldn't have been checked at the start
+      expect(wrapper.vm.isAspectRatioChecked).toBeFalsy();
+
+      wrapper.vm.$refs.videoPlayer.$emit("buffered");
+
+      expect(checkAndSetPlayerAspectRatio).toHaveBeenCalled();
+      expect(wrapper.vm.isAspectRatioChecked).toBeTruthy();
+    });
+
+    describe("session creation", () => {
+      it("session should not be created if unauthenticated when plio request is resolved", async () => {
+        const createSession = jest.spyOn(Plio.methods, "createSession");
+        await mountWrapper({ loadPlio: true });
+
+        expect(createSession).toHaveBeenCalled();
+
+        // 0 `POST` request should have been made
+        expect(mockAxios.post).toHaveBeenCalledTimes(0);
       });
-      wrapper.vm.$refs.plioModal.$emit("submit-question");
-      expect(mockAxios.put).not.toHaveBeenCalled();
-      expect(createEvent).not.toHaveBeenCalled();
-    });
 
-    describe("for authenticated user", () => {
+      describe("authenticated user", () => {
+        beforeEach(async () => {
+          await authenticateUser();
+          await mountWrapper({ loadPlio: true });
+        });
+        it("creates session when plio request is resolved", async () => {
+          // 1 `POST` request should have been made
+          expect(mockAxios.post).toHaveBeenCalledTimes(1);
+          expect(mockAxios.post).toHaveBeenCalledWith("/sessions/", {
+            plio: global.dummyPublishedPlio.data.id,
+          });
+        });
+
+        it("does not create session if opened in preview mode", async () => {
+          mockAxios.reset();
+          await mountWrapper();
+          await wrapper.setProps({
+            previewMode: true,
+          });
+
+          await loadPlio();
+
+          // 0 `POST` request should have been made
+          expect(mockAxios.post).toHaveBeenCalledTimes(0);
+        });
+
+        describe("session data returned", () => {
+          beforeEach(() => {
+            mockAxios.mockResponse(
+              clonedeep(global.dummySession),
+              mockAxios.queue()[0]
+            );
+          });
+
+          it("populates item responses when request to fetch sessions is resolved", async () => {
+            expect(wrapper.vm.itemResponses.length).toBe(
+              global.dummyItemResponses.length
+            );
+            expect(wrapper.vm.numCorrect).toBe(4);
+            expect(wrapper.vm.numWrong).toBe(1);
+            expect(wrapper.vm.numSkipped).toBe(0);
+          });
+          describe("event updates", () => {
+            let watchingEventDBId = 1;
+
+            it("calls updateEvent method for consecutive 'watching' events for a given session", async () => {
+              wrapper.unmount();
+              // mock createSession method
+              jest
+                .spyOn(Plio.methods, "createSession")
+                .mockImplementation(() => {
+                  return new Promise((resolve) => resolve());
+                });
+
+              // mock updateEvent method
+              let updateEvent = jest
+                .spyOn(Plio.methods, "updateEvent")
+                .mockImplementation(() => {
+                  return;
+                });
+
+              // simulating the case where a 'watching' event has already been created
+              await mountWrapper({
+                loadPlio: true,
+                data: {
+                  watchingEventDBId: watchingEventDBId,
+                  sessionDBId: 1,
+                },
+                dummyPlio: global.dummyPublishedPlio,
+              });
+
+              // assert that updateEvent method has been called with the correct params
+              expect(updateEvent).toHaveBeenCalledWith(
+                "watching",
+                watchingEventDBId
+              );
+            });
+
+            it("updates a watching event when updateEvent is called", () => {
+              // spy on the updateEvent method inside EventAPIService
+              let updateEventAPICall = jest.spyOn(
+                EventAPIService,
+                "updateEvent"
+              );
+
+              // Testing the individual method using 'call'
+              // refer to this - https://lmiller1990.github.io/vue-testing-handbook/v3/computed-properties.html#testing-with-call
+              // build a local context object - localThis. It will serve as 'this' in our test.
+              let localThis = {
+                hasSessionStarted: true,
+                isAuthenticated: true,
+                previewMode: false,
+                sessionDBId: 3,
+                player: {
+                  currentTime: 10,
+                },
+              };
+
+              let eventType = "watching";
+
+              // invoke the method using the local context object and appropriate params
+              Plio.methods.updateEvent.call(
+                localThis,
+                eventType,
+                watchingEventDBId
+              );
+
+              // the updateEvent method inside EventAPIService would've been called
+              // An update request would've been made with the correct payload
+              expect(updateEventAPICall).toHaveBeenCalled();
+              expect(mockAxios.put).toHaveBeenCalledTimes(1);
+              expect(mockAxios.put).toHaveBeenCalledWith(
+                `/events/${watchingEventDBId}`,
+                {
+                  type: eventType,
+                  details: {},
+                  player_time: localThis.player.currentTime,
+                  session: localThis.sessionDBId,
+                }
+              );
+            });
+          });
+        });
+      });
+    });
+    describe("submitting question", () => {
+      let createEvent;
+
+      const setupWrapper = async (params = { currentItemIndex: 0 }) => {
+        await mountWrapper({
+          loadPlio: true,
+          data: {
+            currentItemIndex: params.currentItemIndex,
+            itemResponses: clonedeep(global.dummyItemResponses),
+          },
+        });
+      };
+
       beforeEach(async () => {
-        await authenticateUser();
+        createEvent = jest.spyOn(Plio.methods, "createEvent");
+        await setupWrapper();
       });
+
+      it("does not make an API call if the user is not authenticated", async () => {
+        wrapper.vm.$refs.plioModal.$emit("submit-question");
+        expect(mockAxios.put).not.toHaveBeenCalled();
+        expect(createEvent).not.toHaveBeenCalled();
+      });
+
       it("does not make an API call if in preview mode", async () => {
         await wrapper.setProps({
           previewMode: true,
@@ -395,38 +406,68 @@ describe("Plio.vue", () => {
         expect(mockAxios.put).not.toHaveBeenCalled();
         expect(createEvent).not.toHaveBeenCalled();
       });
-      it("makes an API call in non-preview mode", async () => {
-        const showItemMarkersOnSlider = jest.spyOn(
-          Plio.methods,
-          "showItemMarkersOnSlider"
-        );
-        const calculateScorecardMetrics = jest.spyOn(
-          Plio.methods,
-          "calculateScorecardMetrics"
-        );
-        await setupWrapper();
-        wrapper.vm.$refs.plioModal.$emit("submit-question");
-        expect(mockAxios.put).toHaveBeenCalled();
-        expect(createEvent).toHaveBeenCalled();
-        expect(showItemMarkersOnSlider).toHaveBeenCalled();
-        expect(calculateScorecardMetrics).toHaveBeenCalled();
-      });
-      it("converts checkbox answers from set to array", async () => {
-        const currentItemIndex = 4;
-        await setupWrapper({
-          currentItemIndex: currentItemIndex,
+
+      describe("for authenticated user", () => {
+        beforeEach(async () => {
+          await authenticateUser();
         });
-        wrapper.vm.$refs.plioModal.$emit("submit-question");
-        let expectedItemResponse = clonedeep(
-          global.dummyItemResponses[currentItemIndex]
-        );
-        expectedItemResponse["answer"] = Array.from(
-          expectedItemResponse["answer"]
-        );
-        expect(mockAxios.put).toHaveBeenCalledWith(
-          "/session-answers/5",
-          expectedItemResponse
-        );
+        it("does not make an API call if in preview mode", async () => {
+          await wrapper.setProps({
+            previewMode: true,
+          });
+          wrapper.vm.$refs.plioModal.$emit("submit-question");
+          expect(mockAxios.put).not.toHaveBeenCalled();
+          expect(createEvent).not.toHaveBeenCalled();
+        });
+        it("makes an API call in non-preview mode", async () => {
+          const showItemMarkersOnSlider = jest.spyOn(
+            Plio.methods,
+            "showItemMarkersOnSlider"
+          );
+          const calculateScorecardMetrics = jest.spyOn(
+            Plio.methods,
+            "calculateScorecardMetrics"
+          );
+          await setupWrapper();
+          wrapper.vm.$refs.plioModal.$emit("submit-question");
+          expect(mockAxios.put).toHaveBeenCalled();
+          expect(createEvent).toHaveBeenCalled();
+          expect(showItemMarkersOnSlider).toHaveBeenCalled();
+          expect(calculateScorecardMetrics).toHaveBeenCalled();
+        });
+        it("converts checkbox answers from set to array", async () => {
+          const currentItemIndex = 4;
+          await setupWrapper({
+            currentItemIndex: currentItemIndex,
+          });
+          wrapper.vm.$refs.plioModal.$emit("submit-question");
+          let expectedItemResponse = clonedeep(
+            global.dummyItemResponses[currentItemIndex]
+          );
+          expectedItemResponse["answer"] = Array.from(
+            expectedItemResponse["answer"]
+          );
+          expect(mockAxios.put).toHaveBeenCalledWith(
+            "/session-answers/5",
+            expectedItemResponse
+          );
+        });
+      });
+    });
+    describe("skip disabled", () => {
+      beforeEach(async () => {
+        let dummyPublishedPlio = clonedeep(global.dummyPublishedPlio);
+        let dummySettings = clonedeep(global.dummyGlobalSettings);
+        dummySettings
+          .get("player")
+          .children.get("configuration")
+          .children.get("skipEnabled").value = false;
+
+        dummyPublishedPlio.data.config = {
+          settings: SettingsUtilities.encodeMapToPayload(dummySettings),
+        };
+
+        await mountWrapper({ loadPlio: true, dummyPlio: dummyPublishedPlio });
       });
     });
   });

--- a/tests/utils/dummyData.js
+++ b/tests/utils/dummyData.js
@@ -1,3 +1,4 @@
+import SettingsUtilities from "@/services/Functional/Utilities/Settings.js";
 let clonedeep = require("lodash.clonedeep");
 
 global.dummyItemsWithItemDetails = [
@@ -407,68 +408,6 @@ global.dummyUser = {
   auth_org: null,
 };
 
-global.dummyPublishedPlio = {
-  data: {
-    id: 113,
-    name: "dummy plio",
-    uuid: "abcdefghij",
-    failsafe_url: "",
-    status: "published",
-    is_public: true,
-    config: null,
-    created_by: {
-      id: 4,
-      last_login: null,
-      is_superuser: true,
-      first_name: "",
-      last_name: "",
-      is_staff: false,
-      is_active: true,
-      date_joined: "2021-04-21T08:49:09.763295Z",
-      email: "first.last@email.com",
-      mobile: null,
-      avatar_url: null,
-      config: {
-        locale: "en",
-      },
-      created_at: "2021-04-21T08:49:09.763814Z",
-      updated_at: "2021-07-08T09:51:19.145752Z",
-      organizations: [
-        {
-          id: 3,
-          schema_name: "qwertyuiop",
-          name: "Organization 1",
-          shortcode: "o1",
-          created_at: "2021-04-26T09:46:38.972422Z",
-          updated_at: "2021-04-26T09:46:38.972433Z",
-        },
-        {
-          id: 2,
-          schema_name: "asdfghjkla",
-          name: "Organization 2",
-          shortcode: "o2",
-          created_at: "2021-04-21T10:12:51.751152Z",
-          updated_at: "2021-06-30T08:41:41.652160Z",
-        },
-      ],
-      status: "approved",
-      unique_id: null,
-      auth_org: null,
-    },
-    video: {
-      id: 300,
-      url: "https://www.youtube.com/watch?v=jdYJf_ybyVo",
-      title: null,
-      duration: 725,
-      created_at: "2021-06-17T16:14:21.084680Z",
-      updated_at: "2021-07-03T15:25:04.527931Z",
-    },
-    created_at: "2021-07-03T15:00:01.669764Z",
-    updated_at: "2021-07-03T15:25:04.589996Z",
-    items: dummyItemsWithItemDetails,
-  },
-};
-
 global.dummyVideo = {
   id: 300,
   url: "https://www.youtube.com/watch?v=jdYJf_ybyVo",
@@ -707,3 +646,69 @@ global.dummySettingsToRender = new Map(
     ),
   })
 );
+
+global.dummyPublishedPlio = {
+  data: {
+    id: 113,
+    name: "dummy plio",
+    uuid: "abcdefghij",
+    failsafe_url: "",
+    status: "published",
+    is_public: true,
+    config: {
+      settings: SettingsUtilities.encodeMapToPayload(
+        clonedeep(global.dummyGlobalSettings)
+      ),
+    },
+    created_by: {
+      id: 4,
+      last_login: null,
+      is_superuser: true,
+      first_name: "",
+      last_name: "",
+      is_staff: false,
+      is_active: true,
+      date_joined: "2021-04-21T08:49:09.763295Z",
+      email: "first.last@email.com",
+      mobile: null,
+      avatar_url: null,
+      config: {
+        locale: "en",
+      },
+      created_at: "2021-04-21T08:49:09.763814Z",
+      updated_at: "2021-07-08T09:51:19.145752Z",
+      organizations: [
+        {
+          id: 3,
+          schema_name: "qwertyuiop",
+          name: "Organization 1",
+          shortcode: "o1",
+          created_at: "2021-04-26T09:46:38.972422Z",
+          updated_at: "2021-04-26T09:46:38.972433Z",
+        },
+        {
+          id: 2,
+          schema_name: "asdfghjkla",
+          name: "Organization 2",
+          shortcode: "o2",
+          created_at: "2021-04-21T10:12:51.751152Z",
+          updated_at: "2021-06-30T08:41:41.652160Z",
+        },
+      ],
+      status: "approved",
+      unique_id: null,
+      auth_org: null,
+    },
+    video: {
+      id: 300,
+      url: "https://www.youtube.com/watch?v=jdYJf_ybyVo",
+      title: null,
+      duration: 725,
+      created_at: "2021-06-17T16:14:21.084680Z",
+      updated_at: "2021-07-03T15:25:04.527931Z",
+    },
+    created_at: "2021-07-03T15:00:01.669764Z",
+    updated_at: "2021-07-03T15:25:04.589996Z",
+    items: dummyItemsWithItemDetails,
+  },
+};


### PR DESCRIPTION
Fixes #628 


## Summary
- maintaining a variable for the last answered interaction index
- when the video is seeked, if the skip is disabled and there are interactions pending and the timestamp that is being seeked to is greater than the timestamp of the first unanswered interaction index, the viewer is shown that interaction
- when the page is reloaded, if the user was at a timestamp > timestamp of the first unanswered interaction index, we show that interaction.
- if a user clicks on play when on an unanswered question, they are not allowed to move ahead if skip is disabled
 
## Test Plan

<!-- Demonstrate that the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- [ ] ~Test Responsiveness~
   - [ ] Laptop (1200px)
   - [ ] Tablet (760px)
   - [ ] Phone (320px)
- [x] Cross-Browser Testing
   - [ ] Chrome
   - [ ] Firefox
   - [ ] Safari (use BrowserStack)
- [x] Local Language Support
- [ ] Hygiene and Housekeeping
   - [ ] Self-review
   - [ ] Comments have been added appropriately
   - [ ] ~Check for bundle size [here](https://bundlephobia.com/) if adding a package~
   - [x] Added relevant details like Labels/Projects/Milestones etc.
   - [ ] ~If adding or removing any environment variable:~
       - [ ] update `docs/ENV.md`
       - [ ] update Github Workflow files
       - [ ] update DockerFile
       - [ ] update the secrets for staging and production
- [ ] Testing
   - [ ] Wrote tests
   - [ ] Tested locally
   - [ ] Tested on staging
   - [ ] Tested on an actual physical phone
   - [ ] Tested on production
- [ ] ~Lighthouse Checks~
   - [ ] Images have `alt` attributes
   - [ ] Any `<img>` tags have `width` and `height` specified
   - [ ] Any `target="_blank"` links have `rel="noopener"`
   - [ ] Only SVGs are used as images. If PNGs are used, their size has been optimised.
   - [ ] Any SVGs without text have their `aria-label` attributes set
