### PR TITLE
Fix workspace URL inconsistency after logout and login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -804,6 +804,9 @@ export default {
     },
     /** logs out the user */
     logoutUser() {
+      // First clear the active workspace to prevent it from being used during redirect
+      this.unsetActiveWorkspace();
+      
       this.unsetAccessToken().then(() => {
         this.$router.replace({
           name: "Login",
@@ -816,9 +819,6 @@ export default {
         // added here so that if someone clicks on logout while
         // some activity is pending
         this.stopLoading();
-
-        // clear active workspace
-        this.unsetActiveWorkspace();
       });
     },
     onClose(event) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/avantifellows/plio-frontend) and create your branch from `master`.
  2. Run the installation steps from the project's [README.md](https://github.com/avantifellows/plio-frontend#readme).
  3. Please ensure coding standard and conventions are followed. You can find the details at https://vuejs.org/v2/style-guide/#Priority-A-Rules-Essential-Error-Prevention.
  4. Ensure that an issue has been created for the problem this PR attempts to solve and your Pull Request is linked to the issue. Read more how to link PR to an issue at https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue.

-->

Fixes #459

## Summary

This PR fixes the workspace URL inconsistency issue that occurs when logging out from an org workspace and logging back in.

**Issue:**
When a user logs out from an org workspace and logs back in, they would see themselves in the org workspace but the URL would show `/home` instead of `/<workspace>/home`.

**Root Cause:**
The issue was in the logout process:
- The application was redirecting to the login page **before** clearing the active workspace from the store
- Due to this sequence, the workspace information was still present in the store during the redirect
- When logging back in, the application correctly restored the workspace in the state, but the URL path wasn't properly updated to include the workspace shortcode

**Fix:**
Modified the `logoutUser()` function in `App.vue` to:
1. Clear the active workspace state **before** initiating the redirect to the login page
2. Remove the redundant workspace clearing that was happening after the redirect

## Test Plan

- [x] Manually verified the fix by following the steps to reproduce:
  1. Logged in to an account with ≥ 2 workspaces
  2. Switched to org workspace
  3. Logged out
  4. Logged back in
  5. Confirmed that the URL correctly shows the workspace shortcode (e.g., `/af/home` instead of just `/home`)

- [x] Test Responsiveness
   - [x] Laptop (1200px)
   - [x] Tablet (760px)
   - [x] Phone (320px)
- [x] Cross-Browser Testing
   - [x] Chrome
   - [x] Firefox
   - [ ] Safari (use BrowserStack)
- [x] Local Language Support
- [x] Hygiene and Housekeeping
   - [x] Self-review
   - [x] Comments have been added appropriately
   - [x] Check for bundle size [here](https://bundlephobia.com/) if adding a package (N/A - no new packages)
   - [x] Added relevant details like Labels/Projects/Milestones etc.
   - [ ] If adding or removing any environment variable:
       - [ ] update `docs/ENV.md`
       - [ ] update Github Workflow files
       - [ ] update DockerFile
       - [ ] update the secrets for staging and production
       (N/A - no env variable changes)
- [x] Testing
   - [ ] Wrote tests (N/A - simple fix for existing functionality)
   - [x] Tested locally
   - [ ] Tested on staging
   - [ ] Tested on an actual physical phone
   - [ ] Tested on production
- [x] Lighthouse Checks (N/A - no UI changes)
   - [x] Images have `alt` attributes
   - [x] Any `<img>` tags have `width` and `height` specified
   - [x] Any `target="_blank"` links have `rel="noopener"`
   - [x] Only SVGs are used as images. If PNGs are used, their size has been optimised.
   - [x] Any SVGs without text have their `aria-label` attributes set