### PR TITLE
chore: add mex agent memory scaffold (AGENTS.md + .mex/)

### DIFF
--- a/.mex/AGENTS.md
+++ b/.mex/AGENTS.md
@@ -1,0 +1,36 @@
+---
+name: agents
+description: Always-loaded project anchor. Read this first. Contains project identity, non-negotiables, commands, and pointer to ROUTER.md for full context.
+last_updated: 2026-07-11
+---
+
+# Plio Frontend
+
+## What This Is
+Vue 3 single-page app for Plio — a platform to create and watch interactive videos with questions, used by creators (edit/publish plios) and learners (play/answer).
+
+## Non-Negotiables
+- All API calls go through `apiClient()` from `src/services/API/RootClient.js` — never raw axios; interceptors add auth and tenant headers
+- Endpoint URLs live only in `src/services/API/Endpoints.js` — components import from service modules, never hardcode URLs
+- Never commit secrets — `.env` is gitignored; add new vars to `.env.example` as placeholders
+- Tenant-scoped requests need `activeWorkspace` set in the Vuex `auth` module so the `Organization` header is sent
+- User-facing strings go through vue-i18n locales, not hardcoded text
+
+## Commands
+- Dev server: `npm run serve` (port 8080)
+- Unit tests: `npm run test:unit`
+- Lint: `npm run lint`
+- Build: `npm run build` (staging: `npm run build-staging`)
+
+## Scaffold Growth
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `ROUTER.md` and relevant `context/` files
+- Orient: create or update a `patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
+
+The scaffold grows from real work, not just setup. See the GROW step in `ROUTER.md` for details.
+
+## Navigation
+At the start of every session, read `ROUTER.md` before doing anything else.
+For full project context, patterns, and task guidance — everything is there.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -1,0 +1,66 @@
+---
+name: router
+description: Session bootstrap and navigation hub. Read at the start of every session before any task. Contains project state, routing table, and behavioural contract.
+edges:
+  - target: context/architecture.md
+    condition: when working on system design, integrations, or understanding how components connect
+  - target: context/stack.md
+    condition: when working with specific technologies, libraries, or making tech decisions
+  - target: context/conventions.md
+    condition: when writing new code, reviewing code, or unsure about project patterns
+  - target: context/decisions.md
+    condition: when making architectural choices or understanding why something is built a certain way
+  - target: context/setup.md
+    condition: when setting up the dev environment or running the project for the first time
+  - target: patterns/INDEX.md
+    condition: when starting a task — check the pattern index for a matching pattern file
+last_updated: 2026-07-11
+---
+
+# Session Bootstrap
+
+If you haven't already read `AGENTS.md`, read it now — it contains the project identity, non-negotiables, and commands.
+
+Then read this file fully before doing anything else in this session.
+
+## Current Project State
+
+**Working:**
+- Creator flow: login → create/edit plio in Editor → add items and questions → publish
+- Learner flow: Player page plays video, shows questions at timestamps, records sessions/answers/events
+- Auth: Google OAuth, OTP login, and third-party SSO (query params `unique_id` + `api_key`)
+- Multi-workspace support via `activeWorkspace` and the `Organization` request header
+- Jest unit tests (~40 spec files under tests/unit) and Dashboard analytics page
+
+**Not yet built:**
+- No locally runnable e2e suite: the committed TestCafe specs in tests/integration require BrowserStack + live Google OAuth credentials
+
+**Known issues:**
+- Vue CLI toolchain (webpack) is legacy; no migration to Vite is planned or started
+
+## Routing Table
+
+Load the relevant file based on the current task. Always load `context/architecture.md` first if not already in context this session.
+
+| Task type | Load |
+|-----------|------|
+| Understanding how the system works | `context/architecture.md` |
+| Working with a specific technology | `context/stack.md` |
+| Writing or reviewing code | `context/conventions.md` |
+| Making a design decision | `context/decisions.md` |
+| Setting up or running the project | `context/setup.md` |
+| Any specific task | Check `patterns/INDEX.md` for a matching pattern |
+
+## Behavioural Contract
+
+For every task, follow this loop:
+
+1. **CONTEXT** — Load the relevant context file(s) from the routing table above. Check `patterns/INDEX.md` for a matching pattern. If one exists, follow it. Narrate what you load: "Loading architecture context..."
+2. **BUILD** — Do the work. If a pattern exists, follow its Steps. If you are about to deviate from an established pattern, say so before writing any code — state the deviation and why.
+3. **VERIFY** — Load `context/conventions.md` and run the Verify Checklist item by item. State each item and whether the output passes. Do not summarise — enumerate explicitly.
+4. **DEBUG** — If verification fails or something breaks, check `patterns/INDEX.md` for a debug pattern. Follow it. Fix the issue and re-run VERIFY.
+5. **GROW** — After meaningful work, run this binary checklist:
+   - **Ground:** What changed in reality? Name the changed behavior, system, command, dependency, or workflow.
+   - **Record:** If project state changed, update the "Current Project State" section above. If documented facts changed, update the relevant `context/` file surgically.
+   - **Orient:** If this task can recur and no pattern exists, create one in `patterns/` using `patterns/README.md`, then add it to `patterns/INDEX.md`. If a pattern exists but you learned a gotcha, update it.
+   - **Write:** Bump `last_updated` in every scaffold file you changed. If the why matters, run `mex log --type decision "<what changed and why>"` or `mex log "<note>"`.

--- a/.mex/SETUP.md
+++ b/.mex/SETUP.md
@@ -1,0 +1,228 @@
+# Setup — Populate This Scaffold
+
+This file contains the prompts to populate the scaffold. It is NOT the dev environment setup — for that, see `context/setup.md` after population.
+
+This scaffold is currently empty. Follow the steps below to populate it for your project.
+
+## Recommended: Use setup.sh
+
+```bash
+.mex/setup.sh
+```
+
+The script handles everything automatically:
+1. Detects your project state (existing codebase, fresh project, or partial)
+2. Asks which AI tool you use and copies the right config file
+3. Pre-scans your codebase with `mex init` to build a structured brief (~5-8k tokens vs ~50k from AI exploration)
+4. Builds and runs the population prompt — or prints it for manual paste
+
+If you want to populate manually instead, use the prompts below.
+
+## Detecting Your State
+
+**Existing codebase?** Follow Option A.
+**Fresh project, nothing built yet?** Follow Option B.
+**Partially built?** Follow Option A — the agent will flag empty slots it cannot fill yet.
+
+---
+
+## Option A — Existing Codebase
+
+Paste the following prompt into your agent:
+
+---
+
+**SETUP PROMPT — copy everything between the lines:**
+
+```
+You are going to populate an AI context scaffold for this project.
+The scaffold lives in the root of this repository.
+
+Read the following files in order before doing anything else:
+1. ROUTER.md — understand the scaffold structure
+2. context/architecture.md — read the annotation comments to understand what belongs there
+3. context/stack.md — same
+4. context/conventions.md — same
+5. context/decisions.md — same
+6. context/setup.md — same
+
+Then explore this codebase:
+- Read the main entry point(s)
+- Read the folder structure
+- Read 2-3 representative files from each major layer
+- Read any existing README or documentation
+
+PASS 1 — Populate knowledge files:
+
+Populate each context/ file by replacing the annotation comments
+with real content from this codebase. Follow the annotation instructions exactly.
+For each slot:
+- Use the actual names, patterns, and structures from this codebase
+- Do not use generic examples
+- Do not leave any slot empty — if you cannot determine the answer,
+  write "[TO DETERMINE]" and explain what information is needed
+- Keep length within the guidance given in each annotation
+
+Then assess: does this project have domains complex enough that cramming
+them into architecture.md would make it too long or too shallow?
+If yes, create additional domain-specific context files in context/.
+Examples: a project with a complex auth system gets context/auth.md.
+A data pipeline gets context/ingestion.md. A project with Stripe gets
+context/payments.md. Use the same YAML frontmatter format (name,
+description, triggers, edges, last_updated). Only create these for
+domains that have real depth — not for simple integrations that fit
+in a few lines of architecture.md.
+
+After populating context/ files, update ROUTER.md:
+- Fill in the Current Project State section based on what you found
+- Add rows to the routing table for any domain-specific context files you created
+
+Update AGENTS.md:
+- Fill in the project name, one-line description, non-negotiables, and commands
+
+PASS 2 — Generate starter patterns:
+
+Read patterns/README.md for the format and categories.
+
+Generate 3-5 starter patterns for the most common and most dangerous task
+types in this project. Focus on:
+- The 1-2 tasks a developer does most often (e.g., add endpoint, add component)
+- The 1-2 integrations with the most non-obvious gotchas
+- 1 debug pattern for the most common failure boundary
+
+Each pattern should be specific to this project — real file paths, real gotchas,
+real verify steps derived from the code you read in Pass 1.
+Use the format in patterns/README.md. Name descriptively (e.g., add-endpoint.md).
+
+Do NOT try to generate a pattern for every possible task type. The scaffold
+grows incrementally — the behavioural contract (step 5: GROW) will create
+new patterns from real work as the project evolves. Setup just seeds the most
+critical ones.
+
+After generating patterns, update patterns/INDEX.md with a row for each
+pattern file you created. For multi-section patterns, add one row per task
+section using anchor links (see INDEX.md annotation for format).
+
+PASS 3 — Wire the web:
+
+Re-read every file you just wrote (context/ files, pattern files, ROUTER.md).
+For each file, add or update the `edges` array in the YAML frontmatter.
+Each edge should point to another scaffold file that is meaningfully related,
+with a `condition` explaining when an agent should follow that edge.
+
+Rules for edges:
+- Every context/ file should have at least 2 edges
+- Every pattern file should have at least 1 edge (usually to the relevant context file)
+- Edges should be bidirectional where it makes sense (if A links to B, consider B linking to A)
+- Use relative paths (e.g., context/stack.md, patterns/add-endpoint.md)
+- Pattern files can edge to other patterns (e.g., debug pattern → related task pattern)
+
+Important: only write content derived from the codebase.
+Do not include system-injected text (dates, reminders, etc.)
+in any scaffold file.
+
+When done, confirm which files were populated and flag any slots
+you could not fill with confidence.
+```
+
+---
+
+## Option B — Fresh Project
+
+Paste the following prompt into your agent:
+
+---
+
+**SETUP PROMPT — copy everything between the lines:**
+
+```
+You are going to populate an AI context scaffold for a project that
+is just starting. Nothing is built yet.
+
+Read the following files in order before doing anything else:
+1. ROUTER.md — understand the scaffold structure
+2. All files in context/ — read the annotation comments in each
+
+Then ask me the following questions one section at a time.
+Wait for my answer before moving to the next section:
+
+1. What does this project do? (one sentence)
+2. What are the hard rules — things that must never happen in this codebase?
+3. What is the tech stack? (language, framework, database, key libraries)
+4. Why did you choose this stack over alternatives?
+5. How will the major pieces connect? Describe the flow of a typical request/action.
+6. What patterns do you want to enforce from day one?
+7. What are you deliberately NOT building or using?
+
+After I answer, populate the context/ files based on my answers.
+For any slot you cannot fill yet, write "[TO BE DETERMINED]" and note
+what needs to be decided before it can be filled.
+
+Then assess: based on my answers, does this project have domains complex
+enough that cramming them into architecture.md would make it too long
+or too shallow? If yes, create additional domain-specific context files
+in context/. Examples: a project with a complex auth system gets
+context/auth.md. A data pipeline gets context/ingestion.md. A project
+with Stripe gets context/payments.md. Use the same YAML frontmatter
+format (name, description, triggers, edges, last_updated). Only create
+these for domains that have real depth — not for simple integrations
+that fit in a few lines of architecture.md. For fresh projects, mark
+domain-specific unknowns with "[TO BE DETERMINED — populate after first
+implementation]".
+
+Update ROUTER.md current state to reflect that this is a new project.
+Add rows to the routing table for any domain-specific context files you created.
+Update AGENTS.md with the project name, description, non-negotiables, and commands.
+
+Read patterns/README.md for the format and categories.
+
+Generate 2-3 starter patterns for the most obvious task types you can
+anticipate for this stack. Focus on the tasks a developer will do first.
+Mark unknowns with "[VERIFY AFTER FIRST IMPLEMENTATION]".
+
+Do NOT try to anticipate every possible pattern. The scaffold grows
+incrementally — the behavioural contract (step 5: GROW) will create
+new patterns from real work as the project evolves. Setup just seeds
+the most critical ones.
+
+After generating patterns, update patterns/INDEX.md with a row for each
+pattern file you created.
+
+PASS 3 — Wire the web:
+
+Re-read every file you just wrote (context/ files, pattern files, ROUTER.md).
+For each file, add or update the `edges` array in the YAML frontmatter.
+Each edge should point to another scaffold file that is meaningfully related,
+with a `condition` explaining when an agent should follow that edge.
+
+Rules for edges:
+- Every context/ file should have at least 2 edges
+- Every pattern file should have at least 1 edge
+- Edges should be bidirectional where it makes sense
+- Use relative paths (e.g., context/stack.md, patterns/add-endpoint.md)
+
+Important: only write content derived from your answers.
+Do not include system-injected text (dates, reminders, etc.)
+in any scaffold file.
+```
+
+---
+
+## After Setup
+
+**Verify** by starting a fresh session and asking your agent:
+"Read `.mex/ROUTER.md` and tell me what you now know about this project."
+
+A well-populated scaffold should give the agent enough to:
+- Describe the architecture without looking at code
+- Name the non-negotiable conventions
+- Know which files to load for any given task type
+- Know which patterns exist for common task types
+
+## Keeping It Fresh
+
+Once the scaffold is populated, use these to keep it aligned with your codebase:
+
+- **`mex check`** — detect drift (zero tokens, zero AI)
+- **`.mex/sync.sh`** — interactive drift check + targeted or full resync
+- **`mex watch`** — auto drift score after every commit

--- a/.mex/SYNC.md
+++ b/.mex/SYNC.md
@@ -1,0 +1,62 @@
+# Sync — Realign This Scaffold
+
+## Recommended: Use sync.sh
+
+```bash
+.mex/sync.sh
+```
+
+The script runs drift detection first, shows you exactly what's wrong, then offers:
+1. **Targeted sync** — AI fixes only the flagged files (fastest, cheapest)
+2. **Full resync** — AI re-reads everything and updates all scaffold files
+3. **Prompt export** — shows the prompts for manual paste
+4. **Exit** — fix it yourself
+
+## Quick Check
+
+```bash
+mex check              # full drift report
+mex check --quiet      # one-liner: "drift score 85/100 (1 error)"
+mex sync --dry-run     # preview targeted fix prompts
+```
+
+## Manual Resync
+
+If you prefer to paste a prompt manually, or don't have the CLI built:
+
+---
+
+**SYNC PROMPT — copy everything between the lines:**
+
+```
+You are going to resync the AI context scaffold for this project.
+The scaffold may be out of date — the codebase has changed since it was last populated.
+
+First, read all files in context/ to understand the current scaffold state.
+Then explore what has changed in the codebase since the scaffold was last updated.
+Check the last_updated dates in the YAML frontmatter of each file.
+
+For each context/ file:
+1. Compare the current scaffold content to the actual codebase
+2. Identify what has changed, been added, or been removed
+3. Update the file to reflect the current state
+
+Critical rules for updating:
+- Use surgical, targeted edits — NOT full file rewrites. Read the existing content,
+  identify what changed, and update only those sections.
+- PRESERVE YAML frontmatter structure. Never delete or rewrite the entire frontmatter block.
+  Edit individual fields only. The edges, triggers, name, and description fields must
+  survive every sync. If you need to update edges, add or remove individual entries —
+  do not replace the entire array.
+- In context/decisions.md: NEVER delete existing decisions.
+  If a decision has changed, mark the old entry as "Superseded by [new decision title]"
+  and add the new decision above it with today's date.
+- In all other files: update content to reflect current reality
+- Update last_updated in the YAML frontmatter of every file you change
+- After updating each file, update ROUTER.md Current Project State
+
+When done, report:
+- Which files were updated and what changed
+- Any decisions that were superseded
+- Any slots that could not be filled with confidence
+```

--- a/.mex/config.json
+++ b/.mex/config.json
@@ -1,0 +1,10 @@
+{
+  "scaffold_id": "06e9e123-2923-44bd-bffd-3119ee878376",
+  "scaffold_name": "plio-frontend",
+  "origin": null,
+  "upstream": null,
+  "aiTools": [
+    "claude",
+    "codex"
+  ]
+}

--- a/.mex/context/architecture.md
+++ b/.mex/context/architecture.md
@@ -1,0 +1,52 @@
+---
+name: architecture
+description: How the major pieces of this project connect and flow. Load when working on system design, integrations, or understanding how components interact.
+triggers:
+  - "architecture"
+  - "system design"
+  - "how does X connect to Y"
+  - "integration"
+  - "flow"
+edges:
+  - target: context/stack.md
+    condition: when specific technology details are needed
+  - target: context/decisions.md
+    condition: when understanding why the architecture is structured this way
+last_updated: 2026-07-11
+---
+
+# Architecture
+
+## System Overview
+
+User action in a page component (`src/pages`) → calls a resource service in `src/services/API`
+(Plio.js, Item.js, Session.js, …) → each service uses `apiClient()` from `RootClient.js` →
+axios interceptors add `Authorization: Bearer <token>` and `Organization: <activeWorkspace>`
+headers, normalise trailing slashes → request hits the plio-backend REST API →
+response flows back to the component; shared state (auth, workspace, settings) lives in the
+Vuex store. A 401 triggers the centralized re-auth flow in RootClient (refresh token → retry
+original request; on failure → auto-logout). A store plugin (`usersWebSocketPlugin`) keeps a
+WebSocket open to the backend for live user updates when authenticated.
+
+## Key Components
+
+- **`src/pages`** — route-level views: Login, Home (plio list), Editor (create/edit plios), Player (watch/answer), Dashboard (analytics), Error, and Embeds (embedded plio player)
+- **`src/services/API`** — one client module per backend resource plus `RootClient.js` (axios instance + interceptors) and `Endpoints.js` (the single authoritative list of endpoint paths)
+- **`src/services/Functional`** — business utilities used across components (items, user, video, settings logic)
+- **`src/store`** — Vuex 4 store; modules: `auth` (tokens, user, activeWorkspace, settings), `dialog`, `generic`, `selectors`, `sync`; plugins include the users WebSocket plugin
+- **`src/router`** — routes with guards: `requiresAuth`, `guest`, third-party SSO bypass (query `unique_id` + `api_key`), workspace param persistence, document titles
+- **`src/services/Localisation`** — vue-i18n setup; locale JSON files live in `src/locales`
+
+## External Dependencies
+
+- plio-backend REST API (`VUE_APP_BACKEND`) — all data; multi-tenant, so the `Organization` header decides which workspace schema answers
+- plio-backend OAuth endpoints (`VUE_APP_BACKEND_AUTH_URL`) — `/convert-token/` (Google → Plio token), `/token/` (refresh grant), `/generate-external-auth-access-token/` (third-party SSO)
+- plio-backend WebSocket (`VUE_APP_BACKEND_WEBSOCKET`) — live user object updates at `/api/v1/users/<userId>`
+- Google OAuth (via **vue3-google-oauth2**) — social login; needs `VUE_APP_GOOGLE_CLIENT_ID`
+- Mixpanel (**mixpanel-browser**) and Sentry (**@sentry/browser**) — product analytics and error monitoring (staging/production)
+
+## What Does NOT Exist Here
+
+- No business/data logic — validation, permissions, tenancy, and metrics are all backend concerns; this app renders and forwards
+- No server-side rendering and no backend-for-frontend — the SPA talks directly to the Django API
+- No component library — UI is hand-built with Tailwind utility classes

--- a/.mex/context/conventions.md
+++ b/.mex/context/conventions.md
@@ -1,0 +1,75 @@
+---
+name: conventions
+description: How code is written in this project — naming, structure, patterns, and style. Load when writing new code or reviewing existing code.
+triggers:
+  - "convention"
+  - "pattern"
+  - "naming"
+  - "style"
+  - "how should I"
+  - "what's the right way"
+edges:
+  - target: context/architecture.md
+    condition: when a convention depends on understanding the system structure
+last_updated: 2026-07-11
+---
+
+# Conventions
+
+## Naming
+
+- Vue single-file components and pages: PascalCase (`Editor.vue`, `Home.vue`)
+- API service modules: PascalCase singular resource name (`Plio.js`, `Item.js`, `Session.js`) in `src/services/API`
+- Vuex modules: lowercase file names (`auth.js`, `dialog.js`, `generic.js`, `selectors.js`, `sync.js`) in `src/store/modules`
+- Unit tests mirror source paths under tests/unit and end in `.spec.js` (`App.spec.js`, pages/, components/)
+- Env vars: `VUE_APP_*` prefix (required for Vue CLI to expose them to client code)
+
+## Structure
+
+- Route-level views live in `src/pages`; reusable pieces in `src/components` (grouped by feature: Editor, Player, UI, etc.)
+- Every backend resource gets its own service module in `src/services/API` that imports paths from `Endpoints.js` and calls `apiClient()`
+- Cross-cutting business helpers go in `src/services/Functional`, not in components
+- Store state that must survive reload belongs in the persisted `auth` module; ephemeral UI state goes in `dialog`/`generic`
+- Router guards and title handling are centralized in `src/router` — don't put auth checks in components
+
+## Patterns
+
+API access — always through the service layer:
+
+```js
+// Correct
+import PlioService from "@/services/API/Plio.js";
+const plio = await PlioService.getPlio(uuid);
+
+// Wrong — bypasses auth/tenant interceptors
+import axios from "axios";
+await axios.get(`${backend}/plios/${uuid}/`);
+```
+
+Workspace-scoped requests — the `Organization` header comes from state, so set the
+workspace before calling, never pass it manually:
+
+```js
+this.$store.dispatch("auth/setActiveWorkspace", workspaceShortcode);
+// subsequent apiClient() calls now target that workspace's schema
+```
+
+User-facing text — through i18n, never literals:
+
+```js
+// Correct (template)
+{{ $t("home.create_button") }}
+
+// Wrong
+Create Plio
+```
+
+## Verify Checklist
+
+Before presenting any code:
+- [ ] `npm run lint` passes (ESLint + eslint-plugin-vue)
+- [ ] `npm run test:unit` passes; new logic in pages/components has a matching `.spec.js` under tests/unit
+- [ ] No direct axios usage or hardcoded endpoint URLs — services + `Endpoints.js` only
+- [ ] New user-visible strings added to locale files and referenced via `$t(...)`
+- [ ] New env vars added to `.env.example` with `VUE_APP_` prefix
+- [ ] Options API style maintained — no Composition API introduced

--- a/.mex/context/decisions.md
+++ b/.mex/context/decisions.md
@@ -1,0 +1,37 @@
+---
+name: decisions
+description: Key architectural and technical decisions with reasoning. Load when making design choices or understanding why something is built a certain way.
+triggers:
+  - "why do we"
+  - "why is it"
+  - "decision"
+  - "alternative"
+  - "we chose"
+last_updated: 2026-07-11
+---
+
+# Decisions
+
+## Decision Log
+
+### Centralize all HTTP concerns in RootClient interceptors
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** One axios instance (`apiClient()` in `src/services/API/RootClient.js`) owns auth headers, the `Organization` tenant header, URL normalisation, and the 401 refresh-and-retry flow.
+**Reasoning:** Multi-tenancy and token refresh are easy to get wrong per-call; a single choke point means components can't forget a header.
+**Alternatives considered:** Per-service axios instances (rejected — duplicated interceptor logic and drift).
+**Consequences:** Any new API call must go through the service layer; bypassing it silently loses tenancy and re-auth behaviour.
+
+### Encode the active workspace as state, not as a call parameter
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** The current workspace shortcode lives in the Vuex `auth` module (`activeWorkspace`); the interceptor injects it as the `Organization` header on every request. Routes carry an optional `:workspace` param that syncs with the store.
+**Reasoning:** Matches the backend's django-tenants model where the header selects the Postgres schema; keeps components tenant-agnostic.
+**Consequences:** Tests and embeds must set `activeWorkspace` (or use personal workspace default) before making tenant-scoped calls.
+
+### Persist auth state with vuex-persistedstate + secure-ls
+**Date:** 2021 (original architecture, verified 2026-07-11)
+**Status:** Active
+**Decision:** Vuex state (tokens, user, workspace) survives reloads via `vuex-persistedstate`, encrypted in localStorage through `secure-ls`.
+**Reasoning:** SPA reloads shouldn't log users out; plain localStorage would expose tokens.
+**Consequences:** Auth-state shape changes are effectively migrations — stale persisted state in users' browsers must be handled.

--- a/.mex/context/setup.md
+++ b/.mex/context/setup.md
@@ -1,0 +1,63 @@
+---
+name: setup
+description: Dev environment setup and commands. Load when setting up the project for the first time or when environment issues arise.
+triggers:
+  - "setup"
+  - "install"
+  - "environment"
+  - "getting started"
+  - "how do I run"
+  - "local development"
+edges:
+  - target: context/stack.md
+    condition: when specific technology versions or library details are needed
+  - target: context/architecture.md
+    condition: when understanding how components connect during setup
+last_updated: 2026-07-11
+---
+
+# Setup
+
+## Prerequisites
+
+- Node.js + npm (project uses the Vue CLI webpack toolchain)
+- A running plio-backend instance (default local: port 8001) — the app is unusable without the API
+- Docker Desktop (optional — only for the dockerized dev flow in docker-compose.yml)
+- pre-commit (`pip install pre-commit` or `brew install pre-commit`) for the git hooks
+
+## First-time Setup
+
+1. `npm install`
+2. `cp .env.example .env` and fill in values (see Environment Variables below)
+3. `pre-commit install` (dev only)
+4. `npm run serve` — app on http://localhost:8080
+5. Docker alternative: `docker-compose up -d --build` (uses `APP_PORT` from .env)
+
+## Environment Variables
+
+- `VUE_APP_BACKEND` (required) — backend REST base URL, e.g. http://localhost:8001/api/v1
+- `VUE_APP_BACKEND_AUTH_URL` (required) — backend OAuth base (convert-token, token endpoints)
+- `VUE_APP_BACKEND_API_CLIENT_ID` / `VUE_APP_BACKEND_API_CLIENT_SECRET` (required) — OAuth2 client credentials issued by the backend
+- `VUE_APP_BACKEND_WEBSOCKET` (required) — ws(s):// base for live user updates
+- `VUE_APP_FRONTEND` (required) — this app's own base URL
+- `VUE_APP_GOOGLE_CLIENT_ID` / `VUE_APP_GOOGLE_API_KEY` (required for Google login)
+- `VUE_APP_I18N_LOCALE` / `VUE_APP_I18N_FALLBACK_LOCALE` (optional) — default locales
+- `VUE_APP_MIXPANEL_PROJECT_TOKEN` (optional) — analytics
+- `VUE_APP_SENTRY_DSN` (optional) — error monitoring
+- `APP_PORT` (docker only) — container port mapping
+
+## Common Commands
+
+- `npm run serve` — dev server with hot reload on port 8080
+- `npm run test:unit` — Jest unit suite (tests/unit)
+- `npm run lint` — ESLint via vue-cli-service
+- `npm run build` — production build (`--modern`)
+- `npm run build-staging` — staging-mode build
+- `npm run deploy` / `npm run deploy-staging` — build + S3 sync (needs the `plio-s3-bot` AWS profile)
+- `npm run i18n:report` — report missing/unused i18n keys
+
+## Common Issues
+
+**Blank app / all requests 401 or CORS errors:** the backend isn't running or `VUE_APP_BACKEND` points to the wrong port — local backend serves at port 8001, not 8000.
+**Login loop after backend restart:** the persisted OAuth client credentials no longer match — verify `VUE_APP_BACKEND_API_CLIENT_ID/SECRET` against the backend's OAuth2 application and clear localStorage.
+**e2e specs in tests/integration fail immediately:** expected — they need BrowserStack + Google OAuth credentials; there is no locally runnable e2e suite on master.

--- a/.mex/context/stack.md
+++ b/.mex/context/stack.md
@@ -1,0 +1,50 @@
+---
+name: stack
+description: Technology stack, library choices, and the reasoning behind them. Load when working with specific technologies or making decisions about libraries and tools.
+triggers:
+  - "library"
+  - "package"
+  - "dependency"
+  - "which tool"
+  - "technology"
+edges:
+  - target: context/decisions.md
+    condition: when the reasoning behind a tech choice is needed
+  - target: context/conventions.md
+    condition: when understanding how to use a technology in this codebase
+last_updated: 2026-07-11
+---
+
+# Stack
+
+## Core Technologies
+
+- **Vue 3** — framework, Options API style throughout (no Composition API refactor)
+- **@vue/cli-service** — Vue CLI (webpack) build toolchain; dev server, build, lint, and unit tests all run through `vue-cli-service`
+- **Vuex 4** — global state, persisted via `vuex-persistedstate` with `secure-ls` encryption
+- **vue-router** (v4) — routing with per-route guards and workspace-aware params
+- **TailwindCSS** — styling (postcss7-compat build), no component library
+
+## Key Libraries
+
+- **axios** — HTTP; always via the shared `apiClient()` in `src/services/API/RootClient.js`, never imported directly in components
+- **vue-i18n** — all user-facing copy; locale JSONs in `src/locales` (report: `npm run i18n:report`)
+- **plyr** — video player wrapped by the Player page components
+- **vue3-google-oauth2** — Google login flow
+- **mixpanel-browser** — product analytics events
+- **@sentry/browser** + **@sentry/tracing** — error monitoring in staging/production
+- **@vue/cli-plugin-unit-jest** + **@vue/test-utils** — Jest unit tests in tests/unit
+- **vue-toastification**, **vue-tippy** — toasts and tooltips
+- **mathlive** / **katex** — math input and rendering in questions
+
+## What We Deliberately Do NOT Use
+
+- No Composition API — codebase is consistently Options API; don't mix styles
+- No direct axios imports in components — the RootClient interceptors are the only place auth/tenant headers are handled
+- No CSS frameworks besides Tailwind and no scoped CSS conventions — utility classes in templates
+- No TypeScript — plain JS with ESLint (`babel-eslint` parser)
+
+## Version Constraints
+
+- Vue CLI toolchain pins webpack-era plugin versions; upgrading any `@vue/cli-*` package should happen together, not piecemeal
+- `@browserstack/testcafe` devDependencies remain on master for the legacy e2e suite in tests/integration

--- a/.mex/events/decisions.jsonl
+++ b/.mex/events/decisions.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-07-11T17:00:52.698Z","kind":"decision","message":"mex scaffold created and populated (Claude + Codex configs; CLAUDE.md symlinks to AGENTS.md).","files":[],"cwd":"."}

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -1,0 +1,9 @@
+# Pattern Index
+
+Lookup table for all pattern files in this directory. Check here before starting any task — if a pattern exists, follow it.
+
+| Pattern | Use when |
+|---------|----------|
+| [add-api-service.md](add-api-service.md) | Adding a new backend API call or resource client module |
+| [add-page.md](add-page.md) | Adding a new route-level page with guards and i18n |
+| [debug-auth-tenancy.md](debug-auth-tenancy.md) | Diagnosing 401 loops, silent logouts, or wrong/empty workspace data |

--- a/.mex/patterns/README.md
+++ b/.mex/patterns/README.md
@@ -1,0 +1,170 @@
+# Patterns
+
+This folder contains task-specific guidance — the things you would tell your agent if you were sitting next to it. Not generic instructions. Project-specific accumulated wisdom.
+
+## How patterns get created
+
+**During setup:** After the context/ files are populated, the agent generates starter patterns based on the project's actual stack, architecture, and conventions. These are stack-specific — a Flask API project gets different patterns than a React SPA or a CLI tool.
+
+**Over time:** You or your agent add patterns as they emerge from real work — when something breaks, when a task has a non-obvious gotcha, when you've explained the same thing twice.
+
+## What belongs here
+
+A pattern file is worth creating when:
+- A task type is common in this project and has a repeatable workflow
+- There are integration gotchas between components that aren't obvious from code
+- Something broke and you want to prevent it from breaking the same way again
+- A verify checklist specific to one type of task would catch mistakes early
+
+## When to skip a pattern
+
+Default to generating a pattern. Only skip if:
+- The exact same guidance is already in `context/conventions.md` with concrete examples
+- The task truly has no project-specific gotchas (e.g. "how to write a for loop")
+
+If in doubt, generate the pattern. A pattern that turns out to be obvious costs nothing. A missing pattern costs a broken codebase.
+
+## Format
+
+### Single-task pattern (one file = one task)
+
+```markdown
+---
+name: [pattern-name]
+description: [one line — what this pattern covers and when to use it]
+triggers:
+  - "[keyword that should trigger loading this file]"
+edges:
+  - target: "[related file path, e.g. context/conventions.md]"
+    condition: "[when to follow this edge]"
+last_updated: [YYYY-MM-DD]
+---
+
+# [Pattern Name]
+
+## Context
+[What to load or know before starting this task type]
+
+## Steps
+[The workflow — what to do, in what order]
+
+## Gotchas
+[The things that go wrong. What to watch out for.]
+
+## Verify
+[Checklist to run after completing this task type]
+
+## Debug
+[What to check when this task type breaks]
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`
+```
+
+### Multi-section pattern (one file = multiple related tasks)
+
+Use this when tasks share context but differ in steps. Each task gets its own
+`## Task: ...` heading with sub-sections. The Context section is shared at the top.
+
+```markdown
+---
+name: [pattern-name]
+description: [one line — what this pattern file covers]
+triggers:
+  - "[keyword]"
+edges:
+  - target: "[related file path]"
+    condition: "[when to follow this edge]"
+last_updated: [YYYY-MM-DD]
+---
+
+# [Pattern Name]
+
+## Context
+[Shared context for all tasks in this file]
+
+## Task: [First Task Name]
+
+### Steps
+[...]
+
+### Gotchas
+[...]
+
+### Verify
+[...]
+
+## Task: [Second Task Name]
+
+### Steps
+[...]
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`
+```
+
+Do NOT combine unrelated tasks into one file just to reduce file count.
+Only group tasks that genuinely share context.
+
+## How many patterns to generate
+
+Do not use a fixed number. Generate one pattern per:
+- Each major task type a developer does repeatedly in this project
+- Each external dependency with non-obvious integration gotchas
+- Each major failure boundary in the architecture flow
+
+For a simple project this may be 3-4 files. For a complex project this may be 10-15.
+Do not cap based on a number — cap based on whether the pattern adds real value.
+
+## Pattern categories
+
+Walk through each category below. For each one, check the relevant context files
+and generate patterns for everything that applies to this project.
+
+### Category 1 — Common task patterns
+
+The repeatable tasks in this project. What does a developer do most often?
+
+Derive from: `context/architecture.md` (what are the major components?) and
+`context/conventions.md` (what patterns exist for extending them?)
+
+Examples by project type:
+- API: "add new endpoint", "add new model/entity", "add auth to a route"
+- Frontend: "add new page/route", "add new component", "add form with validation"
+- CLI: "add new command", "add new flag/option"
+- Pipeline: "add new pipeline stage", "add new data source"
+- SaaS: "add payment flow", "add user-facing feature", "add admin operation"
+
+### Category 2 — Integration patterns
+
+How to work with the external dependencies in this project.
+
+Every entry in `context/stack.md` "Key Libraries" or `context/architecture.md`
+"External Dependencies" that has non-obvious setup, gotchas, or failure modes
+deserves a pattern. These are the most dangerous areas — the agent will
+confidently write integration code that looks right but misses project-specific
+configuration, error handling, or rate limiting.
+
+Examples: "calling the payments API", "running database migrations",
+"adding a new third-party service client", "configuring auth provider"
+
+### Category 3 — Debug/diagnosis patterns
+
+When something breaks, where do you look?
+
+Derive from the architecture flow — each boundary between components is a
+potential failure point. One debug pattern per major boundary.
+
+Examples: "debug webhook failures", "debug pipeline stage failures",
+"diagnose auth/permission issues", "debug background job failures"
+
+### Category 4 — Deploy/release patterns
+
+Only generate if `context/setup.md` reveals non-trivial deployment.
+
+Examples: "deploy to staging", "rollback a release", "update environment config",
+"run database migration in production"

--- a/.mex/patterns/add-api-service.md
+++ b/.mex/patterns/add-api-service.md
@@ -1,0 +1,46 @@
+---
+name: add-api-service
+description: Adding a new backend resource client to the API service layer, or a new call to an existing one.
+triggers:
+  - "new endpoint"
+  - "api call"
+  - "service module"
+edges:
+  - target: "context/architecture.md"
+    condition: "when unsure how the service layer fits the request flow"
+last_updated: 2026-07-11
+---
+
+# Add an API Service Call
+
+## Context
+All HTTP goes through `apiClient()` from `src/services/API/RootClient.js`. Endpoint path
+strings live only in `src/services/API/Endpoints.js`. One module per backend resource
+(`Plio.js`, `Item.js`, `Session.js`, …).
+
+## Steps
+1. Add the endpoint path to `src/services/API/Endpoints.js` (or reuse an existing resource root).
+2. Create/extend the resource module in `src/services/API` — export named async functions that call `apiClient().get/post/patch/delete`.
+3. Components import the service function; never call `apiClient()` directly from a component.
+4. If the response needs unwrapping/reshaping (like `Plio.js` does with `itemDetails`), do it in the service so components get a stable shape.
+
+## Gotchas
+- RootClient appends a trailing slash to URLs — Django requires it; don't hand-build URLs with query strings in the path (pass `params` instead).
+- The `Organization` header comes from `activeWorkspace` state — a "missing data" bug is often a missing/wrong workspace, not a broken endpoint.
+- The refresh-token call itself must not carry the Bearer header; RootClient already special-cases it — don't route auth-token calls through a resource service.
+
+## Verify
+- [ ] No component imports axios or hardcodes a URL
+- [ ] Endpoint string exists only in `Endpoints.js`
+- [ ] Works in a workspace context (with `activeWorkspace` set) and in personal workspace (unset)
+- [ ] `npm run lint` and `npm run test:unit` pass
+
+## Debug
+- 404 with doubled/missing slashes → check the path in `Endpoints.js`; RootClient normalises but can't fix a wrong root
+- 401 loop → see the auth/tenancy debug pattern
+- Data from the wrong workspace → log the `Organization` header in the request interceptor
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/.mex/patterns/add-page.md
+++ b/.mex/patterns/add-page.md
@@ -1,0 +1,45 @@
+---
+name: add-page
+description: Adding a new route-level page with router guards, workspace params, and i18n.
+triggers:
+  - "new page"
+  - "new route"
+  - "add screen"
+edges:
+  - target: "context/conventions.md"
+    condition: "for naming and structure rules before writing the component"
+last_updated: 2026-07-11
+---
+
+# Add a Page / Route
+
+## Context
+Pages live in `src/pages` (PascalCase .vue). Routes, guards (`requiresAuth`, `guest`,
+SSO bypass), workspace param handling, and document titles are all centralized in `src/router`.
+
+## Steps
+1. Create the page component in `src/pages` — Options API, Tailwind utilities for styling.
+2. Register the route in `src/router`; follow the existing pattern of an optional `:workspace?` prefix for tenant-scoped pages.
+3. Set route `meta` (auth requirement, title key) instead of doing checks inside the component.
+4. Add all user-visible strings to the locale JSONs in `src/locales` and reference with `$t(...)`.
+5. Add a spec under tests/unit/pages mirroring the page name (`.spec.js`).
+
+## Gotchas
+- Auth checks belong in router guards via `meta`, not in `mounted()` — the guards also handle the third-party SSO bypass (`unique_id` + `api_key` query params), which component-level checks would break.
+- The router injects the remembered `activeWorkspace` into route params when absent — deep links must tolerate both `/home` and `/<workspace>/home` shapes.
+- Missing locale keys render raw key paths in the UI; run `npm run i18n:report` to catch them.
+
+## Verify
+- [ ] Route works authenticated and redirects correctly when logged out
+- [ ] Route works with and without a `:workspace` param
+- [ ] Strings resolve in both locales (`npm run i18n:report` clean for the new keys)
+- [ ] Unit spec added and `npm run test:unit` passes
+
+## Debug
+- Redirect loop → conflicting `requiresAuth`/`guest` meta on the route
+- Wrong workspace data after navigation → workspace param and store `activeWorkspace` out of sync
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/.mex/patterns/debug-auth-tenancy.md
+++ b/.mex/patterns/debug-auth-tenancy.md
@@ -1,0 +1,48 @@
+---
+name: debug-auth-tenancy
+description: Diagnosing 401 loops, silent logouts, and wrong-workspace data — the two failure boundaries of this app.
+triggers:
+  - "401"
+  - "logged out"
+  - "auth loop"
+  - "wrong workspace"
+  - "empty list"
+edges:
+  - target: "context/architecture.md"
+    condition: "for the full request/re-auth flow before digging in"
+last_updated: 2026-07-11
+---
+
+# Debug Auth & Tenancy Issues
+
+## Context
+Two headers decide everything: `Authorization: Bearer <accessToken>` and
+`Organization: <activeWorkspace>`. Both are injected by interceptors in
+`src/services/API/RootClient.js` from the Vuex `auth` module. The 401 handler refreshes the
+token and retries once; a failed refresh (400) auto-logs-out and blocks further requests.
+
+## Steps
+1. Reproduce with devtools Network tab open — inspect the failing request's two headers first.
+2. Missing `Authorization` → check `auth.accessToken` in Vuex; if state looks stale, clear localStorage (persisted via secure-ls) and log in again.
+3. Repeated 401 → the refresh grant is failing: verify `VUE_APP_BACKEND_API_CLIENT_ID/SECRET` match an OAuth2 application on the backend, and that `VUE_APP_BACKEND_AUTH_URL` is right.
+4. Data missing/empty but 200 → almost always tenancy: `Organization` header absent or naming a workspace the user isn't a member of. Check `auth.activeWorkspace`.
+5. SSO/embed flows → confirm `unique_id` + `api_key` query params reached the router guard (they bypass login and mint a token via `/generate-external-auth-access-token/`).
+
+## Gotchas
+- Persisted state hides bugs: a code fix may not help users whose localStorage still holds the old state shape — test with storage cleared.
+- The WebSocket plugin reconnects on close; a backend restart can produce console noise that looks like an auth failure but isn't.
+- 401 on the refresh call itself is expected to log the user out — that's the designed terminal state, not a bug.
+
+## Verify
+- [ ] Login → reload → still authenticated (persistence works)
+- [ ] Expired token path: request → refresh → retry succeeds without user-visible error
+- [ ] Workspace switch changes the `Organization` header on the next request
+
+## Debug
+If all else fails, add a temporary log in the request interceptor in `src/services/API/RootClient.js`
+printing method, URL, and both headers — it is the single choke point for every call.
+
+## Update Scaffold
+- [ ] Update `.mex/ROUTER.md` "Current Project State" if what's working/not built has changed
+- [ ] Update any `.mex/context/` files that are now out of date
+- [ ] If this is a new task type without a pattern, create one in `.mex/patterns/` and add to `INDEX.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+---
+name: agents
+description: Always-loaded project anchor. Read this first. Contains project identity, non-negotiables, commands, and pointer to ROUTER.md for full context.
+last_updated: 2026-07-11
+---
+
+# Plio Frontend
+
+## What This Is
+Vue 3 single-page app for Plio — a platform to create and watch interactive videos with questions, used by creators (edit/publish plios) and learners (play/answer).
+
+## Non-Negotiables
+- All API calls go through `apiClient()` from `src/services/API/RootClient.js` — never raw axios; interceptors add auth and tenant headers
+- Endpoint URLs live only in `src/services/API/Endpoints.js` — components import from service modules, never hardcode URLs
+- Never commit secrets — `.env` is gitignored; add new vars to `.env.example` as placeholders
+- Tenant-scoped requests need `activeWorkspace` set in the Vuex `auth` module so the `Organization` header is sent
+- User-facing strings go through vue-i18n locales, not hardcoded text
+
+## Commands
+- Dev server: `npm run serve` (port 8080)
+- Unit tests: `npm run test:unit`
+- Lint: `npm run lint`
+- Build: `npm run build` (staging: `npm run build-staging`)
+
+## After Every Task
+After meaningful work, run GROW:
+- Ground: what changed in reality?
+- Record: update `.mex/ROUTER.md` and relevant `.mex/context/` files
+- Orient: create or update a `.mex/patterns/` runbook if this can recur
+- Write: bump `last_updated` on changed scaffold files and run `mex log` when rationale matters
+
+## Navigation
+At the start of every session, read `.mex/ROUTER.md` before doing anything else.
+For full project context, patterns, and task guidance — everything is there.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

Sets up [mex](https://github.com/mex-memory/mex) — persistent, drift-checked project memory for AI coding agents — on this repo.

- **Root `AGENTS.md`** — small always-loaded anchor (project identity, non-negotiables, commands) read by Codex; **`CLAUDE.md` is a symlink to it** so Claude Code reads the identical config
- **`.mex/ROUTER.md`** — session bootstrap: current project state + routing table into context files
- **`.mex/context/`** — architecture (request flow through RootClient interceptors), stack, conventions, decisions, setup
- **`.mex/patterns/`** — runbooks: add-api-service, add-page, debug-auth-tenancy

## Why

Gives any AI agent session durable, navigable context instead of a cold start, and keeps that context honest: `npx mex-agent check` validates paths, commands, and dependency claims against the real codebase with zero tokens.

## Verification

`npx mex-agent check` → **drift score 100/100** (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)