### PR TITLE
Scratch: prove quarantine lane #433

### DIFF
--- a/tests/e2e/journeys/quarantine-proof.spec.js
+++ b/tests/e2e/journeys/quarantine-proof.spec.js
@@ -1,0 +1,5 @@
+const { test, expect } = require("../fixtures/test");
+
+test("deliberately failing quarantine proof @quarantine", () => {
+  expect(true).toBe(false);
+});


### PR DESCRIPTION
Temporary verification PR for #433. Contains one deliberately failing `@quarantine` spec and will be closed and deleted after the workflow proves the PR check remains green while reporting the failure.