### PR TITLE
Copy package-lock.json into the Docker image so builds honor the pinned dependency tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@
 # FROM node:lts-alpine as base-stage
 FROM node:16-alpine as base-stage
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json ./
 # install dependencies for npm run test:unit
+# the lockfile must be present so npm resolves the pinned dependency tree —
+# a bare package.json resolve pulls latest in-range versions (e.g. plyr 3.8.x
+# is ESM-only and unresolvable by webpack 4, breaking npm run build)
 RUN apk --no-cache --virtual tmp add python3 make g++ && npm install && apk del tmp
 
 # development stage


### PR DESCRIPTION
## Problem

Staging/production image builds are currently **broken** — `npm run build` fails inside Docker with:

```
This dependency was not found: * plyr in ./src/components/UI/Player/VideoPlayer.vue
```

The base stage copies only `package.json`, so every image build re-resolves all in-range versions from scratch. `plyr` (pinned `^3.6.3`, lockfile at 3.7.8) recently published 3.8.4 as ESM-only — `exports` map + `type: module`, no `main` field — which webpack 4 (Vue CLI 4) cannot resolve.

CI never caught this because CI checks out the full repo and `npm install` honors a present lockfile. Only lockfile-less Docker builds re-resolve — so the failure surfaced exclusively at deploy time (see the failed staging deploy run 29571114654).

## Fix

Copy `package-lock.json` alongside `package.json` in the base stage. `npm install` then reproduces the pinned tree, matching CI behavior exactly. This also protects every other carefully-pinned dependency (e.g. `jest-mock-axios` 4.5.0) from the same class of silent drift.

## Verification

Full local `docker build --target build-stage`: plyr resolves to **3.7.8**, `npm run build` compiles successfully, `dist/` produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)