### PR TITLE
Wait for the language dialog in e2e journeys instead of sampling once

### DIFF
--- a/tests/e2e/helpers/language-dialog.js
+++ b/tests/e2e/helpers/language-dialog.js
@@ -1,0 +1,25 @@
+const LANGUAGE_PICKER = '[data-test="languagePicker-en"]';
+
+/**
+ * Dismiss the "Select your language" dialog if it shows.
+ *
+ * The dialog appears for a user with no language set in config and animates
+ * in a few hundred ms after the page settles. A bare `isVisible()` check
+ * races that animation — if it runs before the dialog mounts it returns
+ * false, the dialog then appears, and it intercepts pointer events on the
+ * page (e.g. the Create button) for the rest of the test. Wait briefly for
+ * the dialog instead of sampling once; absence is the common case, so a
+ * short timeout keeps already-dismissed runs fast.
+ */
+async function dismissLanguageDialog(page, { timeout = 5000 } = {}) {
+  const picker = page.locator(LANGUAGE_PICKER);
+  try {
+    await picker.waitFor({ state: "visible", timeout });
+  } catch {
+    return; // no dialog this run — language already chosen
+  }
+  await picker.click();
+  await picker.waitFor({ state: "hidden" });
+}
+
+module.exports = { dismissLanguageDialog };

--- a/tests/e2e/helpers/published-plio.js
+++ b/tests/e2e/helpers/published-plio.js
@@ -1,4 +1,5 @@
 const { getPlioAccessToken } = require("./auth");
+const { dismissLanguageDialog } = require("./language-dialog");
 
 async function stubYouTubeDuration(page) {
   await page.route("https://www.googleapis.com/youtube/v3/videos**", (route) =>
@@ -94,10 +95,7 @@ async function provisionPublishedPlio({ page, request, input, via = "api" }) {
   if (via !== "ui") throw new Error(`Unknown provisioning mode: ${via}`);
 
   await page.goto("/home");
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) {
-    await languagePicker.click();
-  }
+  await dismissLanguageDialog(page);
   const createResponse = page.waitForResponse(
     (response) =>
       new URL(response.url()).pathname.endsWith("/api/v1/plios/") &&

--- a/tests/e2e/journeys/creator-download-report.spec.js
+++ b/tests/e2e/journeys/creator-download-report.spec.js
@@ -1,6 +1,7 @@
 const { execFileSync } = require("child_process");
 const { test, expect } = require("../fixtures/test");
 const { provisionPublishedPlio } = require("../helpers/published-plio");
+const { dismissLanguageDialog } = require("../helpers/language-dialog");
 
 test("creator downloads a well-formed report for a published plio with no learner sessions", async ({
   page,
@@ -21,8 +22,7 @@ test("creator downloads a well-formed report for a published plio with no learne
   const publishedPlio = await provisionPublishedPlio({ request, input });
 
   await page.goto("/home");
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) await languagePicker.click();
+  await dismissLanguageDialog(page);
   const plioRow = page.locator('[data-test="row"]', { hasText: input.title });
   await plioRow.locator('[data-test="toggleButton"]').click();
 

--- a/tests/e2e/journeys/creator-duplicate.spec.js
+++ b/tests/e2e/journeys/creator-duplicate.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require("../fixtures/test");
+const { dismissLanguageDialog } = require("../helpers/language-dialog");
 const {
   provisionPublishedPlio,
   stubYouTubeDuration,
@@ -48,8 +49,7 @@ test("creator duplicates a published plio without changing the original", async 
   const source = await provisionPublishedPlio({ request, input });
 
   await page.goto("/home");
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) await languagePicker.click();
+  await dismissLanguageDialog(page);
   const sourceRow = page.locator('[data-test="row"]', {
     hasText: input.title,
   });

--- a/tests/e2e/journeys/creator-share-embed.spec.js
+++ b/tests/e2e/journeys/creator-share-embed.spec.js
@@ -1,4 +1,5 @@
 const { test, expect } = require("../fixtures/test");
+const { dismissLanguageDialog } = require("../helpers/language-dialog");
 const {
   provisionPublishedPlio,
   stubYouTubeDuration,
@@ -26,8 +27,7 @@ test("creator share link and embed render the published plio Player", async ({
   });
 
   await page.goto(`/edit/${publishedPlio.uuid}`);
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) await languagePicker.click();
+  await dismissLanguageDialog(page);
   await expect(page.locator('[data-test="videoLinkInput"] input')).toHaveValue(
     "https://www.youtube.com/watch?v=jNQXAC9IVRw",
     {

--- a/tests/e2e/journeys/learner-golden-playback.spec.js
+++ b/tests/e2e/journeys/learner-golden-playback.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require("../fixtures/test");
 const { provisionPublishedPlio } = require("../helpers/published-plio");
+const { dismissLanguageDialog } = require("../helpers/language-dialog");
 
 const journey = {
   videoUrl: "https://www.youtube.com/watch?v=jNQXAC9IVRw",
@@ -43,8 +44,7 @@ async function completeJourney(
   await page.goto(`/play/${plio.uuid}`);
   await expect(page.locator(`#plio${plio.uuid} .plyr`)).toBeVisible();
   await sessionCreated;
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) await languagePicker.click();
+  await dismissLanguageDialog(page);
 
   await advanceToQuestion(page);
 

--- a/tests/e2e/journeys/learner-resume.spec.js
+++ b/tests/e2e/journeys/learner-resume.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require("../fixtures/test");
 const { provisionPublishedPlio } = require("../helpers/published-plio");
+const { dismissLanguageDialog } = require("../helpers/language-dialog");
 
 const resumeTime = 6;
 const journey = {
@@ -17,8 +18,7 @@ async function openPlayer(page, uuid) {
   );
   await page.goto(`/play/${uuid}`);
   await expect(page.locator(`#plio${uuid} .plyr`)).toBeVisible();
-  const languagePicker = page.locator('[data-test="languagePicker-en"]');
-  if (await languagePicker.isVisible()) await languagePicker.click();
+  await dismissLanguageDialog(page);
   expect((await sessionResponse).ok()).toBe(true);
 }
 


### PR DESCRIPTION
## Problem

Running the Playwright suite against staging during the Django 5.2 soak, all four **creator** journeys timed out on a blocked Create-button click. Root cause is a latent race in the harness, not the app:

- The "Select your language" dialog appears for a user with no language set and animates in a few hundred ms **after** `/home` settles.
- Six journeys dismissed it with a check-once `if (await picker.isVisible()) await picker.click()` run *immediately* after navigation — before the dialog mounts. The check sees nothing, skips the click, and the dialog then intercepts pointer events on the page (the Create button) until the test times out.
- Learner journeys survived only incidentally: they `await` the video player first, which gives the dialog time to appear before their identical check runs.
- The e2e seed resets the test user's config every run, so the dialog shows every time — this would flake CI too on a slow enough runner.

Backend was serving every flow correctly throughout (API provisioning and Google login both verified 200 against staging).

## Fix

Replace the six copy-pasted check-once dismissals with a shared `dismissLanguageDialog(page)` that **waits** for the dialog with a short timeout and treats absence as the fast, common path.

## Verification

The four previously-failing creator journeys re-run green against staging (6 passed). eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)